### PR TITLE
feat: migrate layout navigation components

### DIFF
--- a/components/ResourceBasePathFixer.test.tsx
+++ b/components/ResourceBasePathFixer.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ResourceBasePathFixer } from './ResourceBasePathFixer';
+
+const appendResourceLink = (href: string) => {
+  const anchor = document.createElement('a');
+  anchor.setAttribute('href', href);
+  document.body.appendChild(anchor);
+  return anchor;
+};
+
+describe('ResourceBasePathFixer', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('prefixes resource links in production builds', async () => {
+    const anchor = appendResourceLink('/resources/data.csv');
+    process.env.NODE_ENV = 'production';
+
+    render(<ResourceBasePathFixer />);
+
+    await waitFor(() => {
+      expect(anchor.getAttribute('href')).toBe('/Business-Operations/resources/data.csv');
+    });
+  });
+
+  it('keeps resource links untouched outside production', async () => {
+    const anchor = appendResourceLink('/resources/data.csv');
+    process.env.NODE_ENV = 'development';
+
+    render(<ResourceBasePathFixer />);
+
+    await waitFor(() => {
+      expect(anchor.getAttribute('href')).toBe('/resources/data.csv');
+    });
+  });
+});

--- a/components/ResourceBasePathFixer.tsx
+++ b/components/ResourceBasePathFixer.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export interface ResourceBasePathFixerProps {
+  selector?: string
+  productionBasePath?: string
+}
+
+export function ResourceBasePathFixer({
+  selector = 'a[href^="/resources/"]',
+  productionBasePath = '/Business-Operations'
+}: ResourceBasePathFixerProps) {
+  useEffect(() => {
+    const prefix = process.env.NODE_ENV === 'production' ? productionBasePath : ''
+    const anchors = document.querySelectorAll<HTMLAnchorElement>(selector)
+    anchors.forEach((anchor) => {
+      const original = anchor.getAttribute('href') ?? ''
+      if (!original.startsWith(prefix)) {
+        anchor.setAttribute('href', `${prefix}${original}`)
+      }
+    })
+  }, [selector, productionBasePath])
+
+  return null
+}

--- a/components/footer.test.tsx
+++ b/components/footer.test.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Footer } from './footer';
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+
+describe('Footer', () => {
+  it('renders footer text and quick links', () => {
+    render(<Footer />);
+
+    expect(screen.getByText(/Math for Business Operations/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Getting Started/i })).toBeInTheDocument();
+  });
+});

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link'
+import { Calculator, TrendingUp } from 'lucide-react'
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border/40 bg-muted/30 mt-auto">
+      <div className="container mx-auto px-4 py-8">
+        <div className="grid gap-8 md:grid-cols-4">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-primary">
+              <Calculator className="h-5 w-5" />
+              <TrendingUp className="h-4 w-4 text-accent" />
+              <h3 className="text-base font-semibold text-foreground">Math for Business Operations</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              An interactive Grade 12 textbook blending applied accounting with Excel automation.
+            </p>
+            <p className="text-sm text-muted-foreground">© 2025 Daniel Bodanske</p>
+          </div>
+
+          <div className="space-y-3">
+            <h4 className="text-base font-medium">Quick Links</h4>
+            <nav className="flex flex-col space-y-2 text-sm text-muted-foreground">
+              <Link className="hover:text-foreground transition-colors" href="/frontmatter/preface">
+                Getting Started
+              </Link>
+              <Link className="hover:text-foreground transition-colors" href="/backmatter/glossary">
+                Glossary
+              </Link>
+              <Link className="hover:text-foreground transition-colors" href="/search">
+                Search
+              </Link>
+              <Link className="hover:text-foreground transition-colors" href="/capstone">
+                Capstone
+              </Link>
+            </nav>
+          </div>
+
+          <div className="space-y-3">
+            <h4 className="text-base font-medium">Teacher Resources</h4>
+            <nav className="flex flex-col space-y-2 text-sm text-muted-foreground">
+              <Link className="hover:text-foreground transition-colors" href="/teacher/course-overview/pbl-methodology">
+                PBL Methodology
+              </Link>
+              <Link className="hover:text-foreground transition-colors" href="/teacher/course-overview/backward-design">
+                Backward Design
+              </Link>
+              <Link className="hover:text-foreground transition-colors" href="/teacher">
+                Teacher Dashboard
+              </Link>
+            </nav>
+          </div>
+
+          <div className="space-y-3">
+            <h4 className="text-base font-medium">Support</h4>
+            <p className="text-sm text-muted-foreground">
+              Questions about the course? Contact your instructor or visit the help center to get support.
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/header.test.tsx
+++ b/components/header.test.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Header, type HeaderProps } from './header';
+import { createLesson } from '@/lib/test-utils/mock-factories';
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+
+describe('Header', () => {
+  const buildProps = (overrides: Partial<HeaderProps> = {}): HeaderProps => ({
+    studentUnits: [
+      createLesson({ id: '00000000-0000-4000-8000-000000000001', unitNumber: 1, title: 'Smart Ledger Launch', slug: 'unit01' }),
+      createLesson({ id: '00000000-0000-4000-8000-000000000002', unitNumber: 2, title: 'Month-End Wizard', slug: 'unit02' })
+    ],
+    teacherUnits: [
+      createLesson({ id: '00000000-0000-4000-8000-000000000003', unitNumber: 3, title: 'Three-Statement Storyboard', slug: 'unit03' })
+    ],
+    ...overrides
+  });
+
+  it('renders student and teacher unit links from props', () => {
+    render(<Header {...buildProps()} />);
+
+    expect(screen.getByRole('link', { name: /Unit 1: Smart Ledger Launch/i })).toHaveAttribute('href', '/student/unit01');
+    expect(screen.getByRole('link', { name: /Unit 3: Three-Statement Storyboard/i })).toHaveAttribute('href', '/teacher/unit03');
+  });
+
+  it('invokes onSearchChange callback when typing into search bar', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    render(<Header {...buildProps({ onSearchChange })} />);
+
+    await user.type(screen.getByPlaceholderText(/search textbook/i), 'ledger');
+
+    expect(onSearchChange).toHaveBeenCalledWith('ledger');
+  });
+
+  it('toggles mobile menu state when the menu button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Header {...buildProps()} />);
+
+    const toggleButton = screen.getByRole('button', { name: /toggle menu/i });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Calculator, Menu, Search, TrendingUp } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { Lesson } from '@/lib/db/schema/validators'
+
+export interface HeaderProps {
+  studentUnits: Lesson[]
+  teacherUnits: Lesson[]
+  onSearchChange?: (value: string) => void
+  getUnitHref?: (lesson: Lesson, audience: 'student' | 'teacher') => string
+}
+
+const defaultHrefBuilder = (lesson: Lesson, audience: 'student' | 'teacher') => `/${audience}/${lesson.slug}`
+
+export function Header({
+  studentUnits,
+  teacherUnits,
+  onSearchChange,
+  getUnitHref = defaultHrefBuilder
+}: HeaderProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  const sortedStudentUnits = useMemo(
+    () => [...studentUnits].sort((a, b) => a.unitNumber - b.unitNumber),
+    [studentUnits]
+  )
+  const sortedTeacherUnits = useMemo(
+    () => [...teacherUnits].sort((a, b) => a.unitNumber - b.unitNumber),
+    [teacherUnits]
+  )
+
+  const handleSearchChange = (value: string) => {
+    onSearchChange?.(value)
+  }
+
+  const renderUnits = (units: Lesson[], audience: 'student' | 'teacher') => (
+    <ul className="space-y-1">
+      {units.map((unit) => (
+        <li key={unit.id}>
+          <Link
+            href={getUnitHref(unit, audience)}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors block"
+          >
+            {`Unit ${unit.unitNumber}: ${unit.title}`}
+          </Link>
+          {unit.description ? (
+            <p className="text-xs text-muted-foreground/80 ml-2">{unit.description}</p>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  )
+
+  return (
+    <header className="border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between gap-4 py-4">
+          <div className="flex flex-col">
+            <Link href="/" className="flex items-center gap-2 text-lg font-semibold">
+              <span className="flex items-center gap-1 text-primary">
+                <Calculator className="h-5 w-5" />
+                <TrendingUp className="h-4 w-4 text-accent" />
+              </span>
+              Math for Business Operations
+            </Link>
+            <span className="text-xs text-muted-foreground">Applied Accounting with Excel</span>
+          </div>
+
+          <nav className="hidden lg:flex items-center gap-4 text-sm font-medium">
+            <Link className="hover:text-primary transition-colors" href="/">
+              Home
+            </Link>
+            <Link className="hover:text-primary transition-colors" href="/frontmatter/preface">
+              Preface
+            </Link>
+            <Link className="hover:text-primary transition-colors" href="/capstone">
+              Capstone
+            </Link>
+            <Link className="hover:text-primary transition-colors" href="/backmatter/glossary">
+              Glossary
+            </Link>
+            <Link className="hover:text-primary transition-colors" href="/search">
+              Search
+            </Link>
+          </nav>
+
+          <div className="hidden md:flex items-center gap-2">
+            <Input
+              aria-label="Search textbook"
+              placeholder="Search textbook..."
+              onChange={(event) => handleSearchChange(event.target.value)}
+              className="w-64"
+            />
+            <Button variant="outline" size="icon">
+              <Search className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="lg:hidden"
+            aria-label="Toggle menu"
+            aria-expanded={mobileMenuOpen}
+            onClick={() => setMobileMenuOpen((value) => !value)}
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <div
+          className={`lg:grid lg:grid-cols-2 gap-8 border-t border-border/40 py-4 ${
+            mobileMenuOpen ? 'block' : 'hidden'
+          } lg:block`}
+        >
+          <div>
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold">Student Units</p>
+              <span className="text-xs text-muted-foreground">{sortedStudentUnits.length} units</span>
+            </div>
+            {renderUnits(sortedStudentUnits, 'student')}
+          </div>
+
+          <div className="mt-6 lg:mt-0">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold">Teacher Resources</p>
+              <span className="text-xs text-muted-foreground">{sortedTeacherUnits.length} units</span>
+            </div>
+            {renderUnits(sortedTeacherUnits, 'teacher')}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/navigation-sidebar.test.tsx
+++ b/components/navigation-sidebar.test.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NavigationSidebar } from './navigation-sidebar';
+import { createLesson } from '@/lib/test-utils/mock-factories';
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+
+describe('NavigationSidebar', () => {
+  const lessons = [
+    createLesson({ id: '00000000-0000-4000-8000-000000000020', unitNumber: 2, title: 'Month-End Wizard', slug: 'unit02', metadata: { duration: 60, difficulty: 'intermediate' } }),
+    createLesson({ id: '00000000-0000-4000-8000-000000000010', unitNumber: 1, title: 'Smart Ledger Launch', slug: 'unit01', metadata: { duration: 45, difficulty: 'beginner' } })
+  ];
+
+  it('orders lessons by unit number and renders metadata', () => {
+    render(<NavigationSidebar lessons={lessons} />);
+
+    const unitLinks = screen.getAllByRole('link', { name: /Unit/i });
+    expect(unitLinks[0]).toHaveTextContent('Unit 1');
+    expect(unitLinks[1]).toHaveTextContent('Unit 2');
+
+    expect(screen.getByText(/45 min/i)).toBeInTheDocument();
+    expect(screen.getByText(/beginner/i)).toBeInTheDocument();
+  });
+
+  it('uses custom getLessonUrl callback when provided', () => {
+    render(
+      <NavigationSidebar
+        lessons={lessons}
+        getLessonUrl={(lesson) => `/custom/${lesson.slug}`}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: /Unit 1/ })).toHaveAttribute('href', '/custom/unit01');
+  });
+});

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -1,0 +1,141 @@
+import type { ComponentType, SVGProps } from 'react'
+
+import Link from 'next/link'
+import {
+  BarChart3,
+  BookMarked,
+  BookOpen,
+  Briefcase,
+  Calculator,
+  DollarSign,
+  GraduationCap,
+  Home,
+  PieChart,
+  Search,
+  Target,
+  TrendingUp
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import type { Lesson } from '@/lib/db/schema/validators'
+
+export interface NavigationSidebarLink {
+  title: string
+  url: string
+  icon?: ComponentType<SVGProps<SVGSVGElement>>
+}
+
+export interface NavigationSidebarProps {
+  lessons: Lesson[]
+  mainLinks?: NavigationSidebarLink[]
+  additionalLinks?: NavigationSidebarLink[]
+  getLessonUrl?: (lesson: Lesson) => string
+  className?: string
+}
+
+const defaultMainLinks: NavigationSidebarLink[] = [
+  { title: 'Home', url: '/', icon: Home },
+  { title: 'Preface', url: '/frontmatter/preface', icon: BookOpen }
+]
+
+const defaultAdditionalLinks: NavigationSidebarLink[] = [
+  { title: 'Capstone', url: '/capstone', icon: GraduationCap },
+  { title: 'Glossary', url: '/backmatter/glossary', icon: BookMarked },
+  { title: 'Search', url: '/search', icon: Search }
+]
+
+const unitIcons = [Calculator, TrendingUp, BarChart3, PieChart, DollarSign, Target, Briefcase, BookOpen]
+
+const formatDuration = (lesson: Lesson) => {
+  const duration = lesson.metadata?.duration
+  if (!duration) return 'Flexible duration'
+  return `${duration} min`
+}
+
+const formatDifficulty = (lesson: Lesson) => {
+  const difficulty = lesson.metadata?.difficulty
+  return difficulty ? `${difficulty.charAt(0).toUpperCase()}${difficulty.slice(1)}` : 'Mixed level'
+}
+
+const getLessonIcon = (lesson: Lesson) => unitIcons[(lesson.unitNumber - 1) % unitIcons.length] ?? Calculator
+
+const defaultLessonUrl = (lesson: Lesson) => `/units/${lesson.slug}`
+
+export function NavigationSidebar({
+  lessons,
+  mainLinks = defaultMainLinks,
+  additionalLinks = defaultAdditionalLinks,
+  getLessonUrl = defaultLessonUrl,
+  className
+}: NavigationSidebarProps) {
+  const sortedLessons = [...lessons].sort((a, b) => a.unitNumber - b.unitNumber)
+
+  const renderLinks = (links: NavigationSidebarLink[]) => (
+    <ul className="space-y-1">
+      {links.map((link) => {
+        const Icon = link.icon ?? BookOpen
+        return (
+          <li key={link.title}>
+            <Link
+              href={link.url}
+              className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Icon className="h-4 w-4" />
+              {link.title}
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+
+  return (
+    <aside
+      className={cn(
+        'w-full max-w-xs space-y-6 rounded-xl border border-border/40 bg-card p-4 shadow-sm',
+        className
+      )}
+    >
+      <section>
+        <p className="text-sm font-semibold text-foreground">Getting Started</p>
+        {renderLinks(mainLinks)}
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">Course Units</p>
+          <p className="text-xs text-muted-foreground">Guided projects and lessons</p>
+        </div>
+        <ul className="space-y-2">
+          {sortedLessons.map((lesson) => {
+            const Icon = getLessonIcon(lesson)
+            return (
+              <li key={lesson.id} className="rounded-lg border border-border/30 p-3">
+                <Link href={getLessonUrl(lesson)} className="flex items-start gap-3">
+                  <Icon className="mt-1 h-4 w-4 text-primary" />
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-foreground">
+                        {`Unit ${lesson.unitNumber}: ${lesson.title}`}
+                      </span>
+                      <span className="text-xs text-muted-foreground">{formatDuration(lesson)}</span>
+                    </div>
+                    {lesson.description ? (
+                      <p className="text-xs text-muted-foreground mt-1">{lesson.description}</p>
+                    ) : null}
+                    <span className="text-xs font-medium text-primary/80">{formatDifficulty(lesson)}</span>
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+
+      <section>
+        <p className="text-sm font-semibold text-foreground">Additional Resources</p>
+        {renderLinks(additionalLinks)}
+      </section>
+    </aside>
+  )
+}

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
+  value?: number;
+}
+
+export function Progress({ value = 0, className, ...props }: ProgressProps) {
+  const clampedValue = Math.max(0, Math.min(100, value));
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(clampedValue)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={cn('h-2 w-full rounded-full bg-muted', className)}
+      {...props}
+    >
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${clampedValue}%` }}
+      />
+    </div>
+  );
+}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,7 @@
+import type { HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export function Separator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div role="separator" className={cn('h-px w-full bg-border/60', className)} {...props} />;
+}

--- a/components/unit-sidebar.test.tsx
+++ b/components/unit-sidebar.test.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UnitSidebar } from './unit-sidebar';
+import { createLesson, createPhase, createStudentProgress } from '@/lib/test-utils/mock-factories';
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+
+describe('UnitSidebar', () => {
+  const lessons = [
+    createLesson({ id: '00000000-0000-4000-8000-000000000101', unitNumber: 5, orderIndex: 1, title: 'Ledger Fundamentals', slug: 'unit05-lesson01', metadata: { duration: 45 } }),
+    createLesson({ id: '00000000-0000-4000-8000-000000000102', unitNumber: 5, orderIndex: 2, title: 'Budget Challenge', slug: 'unit05-lesson02', metadata: { duration: 50 } })
+  ];
+
+  const phases = [
+    createPhase({ id: '00000000-0000-4000-8000-000000000201', lessonId: '00000000-0000-4000-8000-000000000101' }),
+    createPhase({ id: '00000000-0000-4000-8000-000000000202', lessonId: '00000000-0000-4000-8000-000000000101' }),
+    createPhase({ id: '00000000-0000-4000-8000-000000000203', lessonId: '00000000-0000-4000-8000-000000000102' }),
+    createPhase({ id: '00000000-0000-4000-8000-000000000204', lessonId: '00000000-0000-4000-8000-000000000102' })
+  ];
+
+  const progressEntries = [
+    createStudentProgress({ phaseId: '00000000-0000-4000-8000-000000000201', status: 'completed' }),
+    createStudentProgress({ phaseId: '00000000-0000-4000-8000-000000000202', status: 'in_progress' })
+  ];
+
+  it('shows unit summary information and progress', () => {
+    render(
+      <UnitSidebar
+        unitId="unit-5"
+        unitNumber={5}
+        unitTitle="PayDay Simulator"
+        lessons={lessons}
+        phases={phases}
+        progressEntries={progressEntries}
+        currentLessonId="lesson-b"
+        getLessonHref={(lesson) => `/student/${lesson.slug}`}
+      />
+    );
+
+    expect(screen.getByText(/Unit 5/)).toBeInTheDocument();
+    expect(screen.getByText(/PayDay Simulator/)).toBeInTheDocument();
+    expect(screen.getByText(/2 lessons/)).toBeInTheDocument();
+    expect(screen.getByText(/95 min total/)).toBeInTheDocument();
+
+    // Progress derived from StudentProgress entries (75% for first lesson, 0% for second => 38% overall)
+    expect(screen.getByText(/38% Complete/)).toBeInTheDocument();
+    expect(screen.getByText('Lessons')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /2\. Budget Challenge/ })).toHaveAttribute('href', '/student/unit05-lesson02');
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+});

--- a/components/unit-sidebar.tsx
+++ b/components/unit-sidebar.tsx
@@ -1,0 +1,152 @@
+import Link from 'next/link'
+import { BookOpen, CheckCircle2 } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import type { Lesson, Phase, StudentProgress } from '@/lib/db/schema/validators'
+
+export interface UnitSidebarProps {
+  unitId: string
+  unitNumber: number
+  unitTitle: string
+  lessons: Lesson[]
+  phases?: Phase[]
+  progressEntries?: StudentProgress[]
+  currentLessonId?: string
+  getLessonHref?: (lesson: Lesson) => string
+}
+
+const defaultLessonHref = (lesson: Lesson) => `/lessons/${lesson.slug}`
+
+const statusScore: Record<StudentProgress['status'], number> = {
+  completed: 1,
+  in_progress: 0.5,
+  not_started: 0
+}
+
+export function UnitSidebar({
+  unitNumber,
+  unitTitle,
+  lessons,
+  phases = [],
+  progressEntries = [],
+  currentLessonId,
+  getLessonHref = defaultLessonHref
+}: UnitSidebarProps) {
+  const sortedLessons = [...lessons].sort((a, b) => a.orderIndex - b.orderIndex)
+
+  const totalDuration = sortedLessons.reduce((sum, lesson) => sum + (lesson.metadata?.duration ?? 0), 0)
+
+  const getLessonPhases = (lessonId: string) => phases.filter((phase) => phase.lessonId === lessonId)
+
+  const getLessonProgress = (lessonId: string) => {
+    const lessonPhases = getLessonPhases(lessonId)
+    if (lessonPhases.length === 0) return 0
+
+    const totalScore = lessonPhases.reduce((acc, phase) => {
+      const record = progressEntries.find((entry) => entry.phaseId === phase.id)
+      return acc + (record ? statusScore[record.status] : 0)
+    }, 0)
+
+    return Math.round((totalScore / lessonPhases.length) * 100)
+  }
+
+  const lessonProgressValues = sortedLessons.map((lesson) => getLessonProgress(lesson.id))
+  const unitProgress = lessonProgressValues.length
+    ? Math.round(lessonProgressValues.reduce((sum, value) => sum + value, 0) / lessonProgressValues.length)
+    : 0
+
+  const formatDuration = (duration: number) => {
+    if (duration <= 0) return 'Flexible pacing'
+    return `${duration} min`
+  }
+
+  return (
+    <aside className="w-full space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle className="text-lg">Unit {unitNumber}</CardTitle>
+              <p className="text-sm text-muted-foreground">{unitTitle}</p>
+            </div>
+            <Badge variant="outline" className="text-xs">
+              {unitProgress}% Complete
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <div className="flex justify-between text-sm">
+              <span>Overall Progress</span>
+              <span>{unitProgress}%</span>
+            </div>
+            <Progress value={unitProgress} />
+          </div>
+
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{sortedLessons.length} lessons</span>
+            <span>{formatDuration(totalDuration)} total</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <BookOpen className="h-4 w-4" />
+            Lessons
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {sortedLessons.map((lesson) => {
+            const lessonProgress = getLessonProgress(lesson.id)
+            const isActive = currentLessonId === lesson.id
+            return (
+              <div key={lesson.id} className="space-y-1">
+                <Link
+                  href={getLessonHref(lesson)}
+                  className={cn(
+                    'flex items-center justify-between rounded-lg border px-3 py-2 text-left transition-colors',
+                    isActive ? 'border-primary/50 bg-primary/5' : 'border-border/50 hover:bg-muted'
+                  )}
+                >
+                  <div>
+                    <p className="text-sm font-medium">
+                      {lesson.orderIndex}. {lesson.title}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{formatDuration(lesson.metadata?.duration ?? 0)}</p>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{lessonProgress}%</span>
+                    {lessonProgress === 100 ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : null}
+                  </div>
+                </Link>
+                <Progress value={lessonProgress} className="h-1" />
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Quick Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href={`/student/unit${unitNumber.toString().padStart(2, '0')}`}>
+              View Unit Overview
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </aside>
+  )
+}

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -3,7 +3,7 @@ title: Project Retrospective
 type: retrospective
 status: active
 created: 2025-11-05
-updated: 2025-11-06
+updated: 2025-11-07
 ---
 
 # Project Retrospective
@@ -60,3 +60,15 @@ Focused summary of learnings from Epic #2 (issues #3–#12).
 ### Lessons
 - Capture Supabase result shapes defensively when using postgres-js.
 - Keep brownfield symlinks (e.g., `bus-math-nextjs`) out of TS programs or builds explode.
+
+## PR #25 - feat/25-task-2-layout--navigation-components-5-components
+
+### Highlights
+- Header/footer/navigation/unit sidebars now pull from `Lesson` + `StudentProgress` data, so v2 layouts stay in sync with Supabase payloads.
+- Added Vitest suites for all five components (including `ResourceBasePathFixer`) to lock in data-driven behavior before wiring into app routes.
+- Hardened tooling by ignoring `.next/` in ESLint and swapping Tailwind plugins to pure ESM so lint/build stay green post-migration.
+
+### Lessons
+- Progress UI needs both `Phase` metadata and `student_progress` rows; provide helper functions instead of ad-hoc context for easier testing.
+- Prefer lightweight primitives over porting every shadcn helper—custom sheet/sidebar knockoffs avoided extra dependencies while meeting UX goals.
+- Remember to append retrospective updates as part of change-integrator flow so specs/tests + learnings travel together.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,13 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [
+      "**/.next/**",
+      "node_modules/**",
+      "bus-math-nextjs/**"
+    ]
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/lib/test-utils/mock-factories.test.ts
+++ b/lib/test-utils/mock-factories.test.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -59,5 +60,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- migrate header/footer/navigation/unit sidebar/resource fixer from v1 to Supabase-driven v2 components
- add Vitest coverage for layout primitives and ensure ESLint/Tailwind configs stay compatible
- document highlights/lessons for PR #25 in docs/RETROSPECTIVE.md

Closes #25

## Testing
- npm run lint
- npm run test
- npm run build