### PR TITLE
feat: unit structure components

### DIFF
--- a/components/unit/AssessmentOverview.test.tsx
+++ b/components/unit/AssessmentOverview.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AssessmentOverview } from './AssessmentOverview';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('AssessmentOverview', () => {
+  it('displays performance task details and requirements', () => {
+    const unitContent = buildUnitContent({
+      assessment: {
+        performanceTask: {
+          title: 'Board Review',
+          description: 'Present key insights to Sarah Chen.',
+          requirements: ['4-minute board readout', 'Live spreadsheet walkthrough'],
+          context: 'Students simulate an investor diligence meeting'
+        },
+        milestones: [
+          {
+            id: 'milestone-a',
+            day: 2,
+            title: 'Scenario modeling draft',
+            description: 'Complete base financial model',
+            criteria: ['All tabs linked', 'Assumptions documented']
+          }
+        ],
+        rubric: [
+          {
+            name: 'Storytelling',
+            weight: '20%',
+            exemplary: 'Narrative ties to data seamlessly',
+            proficient: 'Clear narrative with minor gaps',
+            developing: 'Narrative is unclear'
+          }
+        ]
+      }
+    });
+
+    render(<AssessmentOverview assessment={unitContent.assessment} />);
+
+    expect(screen.getByText('Board Review')).toBeInTheDocument();
+    expect(screen.getByText('4-minute board readout')).toBeInTheDocument();
+    expect(screen.getByText(/Scenario modeling draft/)).toBeInTheDocument();
+    expect(screen.getByText(/Storytelling/)).toBeInTheDocument();
+  });
+});

--- a/components/unit/AssessmentOverview.tsx
+++ b/components/unit/AssessmentOverview.tsx
@@ -1,0 +1,109 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type UnitAssessment } from '@/lib/db/schema/lessons';
+import { CheckCircle, Star, Target } from 'lucide-react';
+
+interface AssessmentOverviewProps {
+  assessment: UnitAssessment;
+}
+
+export function AssessmentOverview({ assessment }: AssessmentOverviewProps) {
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold flex items-center gap-2">
+        <Target className="h-6 w-6 text-green-600" />
+        Assessment Overview
+      </h2>
+
+      <Card className="border-green-200">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Star className="h-5 w-5 text-yellow-500" />
+            Final Performance Task
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <h4 className="text-lg font-semibold">{assessment.performanceTask.title}</h4>
+            <p className="text-muted-foreground">{assessment.performanceTask.description}</p>
+          </div>
+
+          {assessment.performanceTask.context ? (
+            <div className="rounded-lg bg-blue-50 p-3 text-sm">
+              <strong>Context:</strong> {assessment.performanceTask.context}
+            </div>
+          ) : null}
+
+          <div>
+            <h5 className="font-medium mb-2">Requirements:</h5>
+            <ul className="space-y-1">
+              {assessment.performanceTask.requirements.map((requirement, index) => (
+                <li key={`requirement-${index}`} className="text-sm flex items-start gap-2">
+                  <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-600" />
+                  <span>{requirement}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">Key Milestones</h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          {assessment.milestones.map((milestone) => (
+            <Card key={milestone.id} className="border-blue-200">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center justify-between text-sm">
+                  <span>{milestone.title}</span>
+                  <Badge variant="outline">Day {milestone.day}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="mb-3 text-sm text-muted-foreground">{milestone.description}</p>
+                <ul className="space-y-1 text-xs">
+                  {milestone.criteria.map((criterion, index) => (
+                    <li key={`${milestone.id}-criterion-${index}`} className="flex items-start gap-2">
+                      <span className="mt-1 text-blue-600">•</span>
+                      <span>{criterion}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Assessment Rubric</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {assessment.rubric.map((criteria, index) => (
+            <div key={`rubric-${index}`} className="rounded-lg border p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <h4 className="font-medium">{criteria.name}</h4>
+                <Badge variant="secondary">{criteria.weight}</Badge>
+              </div>
+              <div className="grid gap-3 text-sm md:grid-cols-3">
+                <div>
+                  <div className="font-medium text-green-700">Exemplary</div>
+                  <p className="text-muted-foreground">{criteria.exemplary}</p>
+                </div>
+                <div>
+                  <div className="font-medium text-yellow-700">Proficient</div>
+                  <p className="text-muted-foreground">{criteria.proficient}</p>
+                </div>
+                <div>
+                  <div className="font-medium text-red-700">Developing</div>
+                  <p className="text-muted-foreground">{criteria.developing}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/components/unit/DrivingQuestion.test.tsx
+++ b/components/unit/DrivingQuestion.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DrivingQuestion } from './DrivingQuestion';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('DrivingQuestion', () => {
+  it('renders the question, context, and scenario', () => {
+    const unitContent = buildUnitContent();
+
+    render(<DrivingQuestion drivingQuestion={unitContent.drivingQuestion} />);
+
+    expect(screen.getByText(/How can we build/i)).toBeInTheDocument();
+    expect(screen.getByText(/Teams use TechStart/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sarah Chen/)).toBeInTheDocument();
+  });
+
+  it('returns null when no driving question is provided', () => {
+    const { container } = render(<DrivingQuestion />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/unit/DrivingQuestion.tsx
+++ b/components/unit/DrivingQuestion.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { type UnitDrivingQuestion } from '@/lib/db/schema/lessons';
+import { HelpCircle } from 'lucide-react';
+
+interface DrivingQuestionProps {
+  drivingQuestion?: UnitDrivingQuestion;
+}
+
+export function DrivingQuestion({ drivingQuestion }: DrivingQuestionProps) {
+  if (!drivingQuestion) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-2xl font-semibold flex items-center gap-2">
+        <HelpCircle className="h-6 w-6 text-blue-600" />
+        Driving Question
+      </h2>
+
+      <Card className="border-l-4 border-l-primary bg-gradient-to-r from-blue-50/50 to-transparent">
+        <CardContent className="pt-6 space-y-4">
+          <blockquote className="text-lg font-semibold text-primary">
+            &ldquo;{drivingQuestion.question}&rdquo;
+          </blockquote>
+
+          <p className="text-muted-foreground leading-relaxed">{drivingQuestion.context}</p>
+
+          {drivingQuestion.scenario ? (
+            <div className="mt-2 rounded-lg border bg-muted/40 p-4 text-sm">
+              <strong>Scenario:</strong> {drivingQuestion.scenario}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/components/unit/LearningSequence.test.tsx
+++ b/components/unit/LearningSequence.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LearningSequence } from './LearningSequence';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('LearningSequence', () => {
+  it('renders weeks, days, activities, and milestones', () => {
+    const unitContent = buildUnitContent({
+      learningSequence: {
+        weeks: [
+          {
+            weekNumber: 1,
+            title: 'Foundations',
+            description: 'Kickoff and baseline skills',
+            days: [
+              {
+                day: 1,
+                focus: 'Launch',
+                activities: ["Watch Sarah's story"],
+                resources: ['Overview page'],
+                milestone: 'Define challenge'
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    render(<LearningSequence learningSequence={unitContent.learningSequence} />);
+
+    expect(screen.getByText(/Week 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Launch/)).toBeInTheDocument();
+    expect(screen.getByText(/Watch Sarah's story/)).toBeInTheDocument();
+    expect(screen.getByText(/Define challenge/)).toBeInTheDocument();
+  });
+});

--- a/components/unit/LearningSequence.tsx
+++ b/components/unit/LearningSequence.tsx
@@ -1,0 +1,91 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type UnitLearningSequence } from '@/lib/db/schema/lessons';
+import { BookOpen, Calendar, Target } from 'lucide-react';
+
+interface LearningSequenceProps {
+  learningSequence: UnitLearningSequence;
+}
+
+export function LearningSequence({ learningSequence }: LearningSequenceProps) {
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold flex items-center gap-2">
+        <Calendar className="h-6 w-6 text-purple-600" />
+        Learning Sequence
+      </h2>
+
+      <div className="space-y-6">
+        {learningSequence.weeks.map((week) => (
+          <Card key={week.weekNumber} className="border-purple-200">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Badge variant="outline" className="bg-purple-100 text-purple-800">
+                  Week {week.weekNumber}
+                </Badge>
+                <span>{week.title}</span>
+              </CardTitle>
+              <p className="text-muted-foreground">{week.description}</p>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4">
+                {week.days.map((day) => (
+                  <div key={`${week.weekNumber}-day-${day.day}`} className="border-l-2 border-purple-200 pl-4">
+                    <div className="mb-2 flex flex-wrap items-center gap-3">
+                      <Badge variant="secondary" className="text-xs">
+                        Day {day.day}
+                      </Badge>
+                      <h4 className="font-medium">{day.focus}</h4>
+                      {day.milestone ? (
+                        <Badge variant="outline" className="flex items-center gap-1 text-xs text-yellow-800">
+                          <Target className="h-3 w-3" />
+                          Milestone
+                        </Badge>
+                      ) : null}
+                    </div>
+
+                    <div className="space-y-2 text-sm">
+                      <div>
+                        <h5 className="mb-1 flex items-center gap-1 font-medium text-muted-foreground">
+                          <BookOpen className="h-3 w-3" />
+                          Activities
+                        </h5>
+                        <ul className="ml-4 space-y-1">
+                          {day.activities.map((activity, index) => (
+                            <li key={`activity-${week.weekNumber}-${day.day}-${index}`} className="flex items-start gap-2">
+                              <span className="text-purple-600">•</span>
+                              <span>{activity}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+
+                      {day.resources.length ? (
+                        <div>
+                          <h5 className="mb-1 font-medium text-muted-foreground">Resources</h5>
+                          <div className="ml-4 flex flex-wrap gap-1">
+                            {day.resources.map((resource, index) => (
+                              <Badge key={`resource-${week.weekNumber}-${day.day}-${index}`} variant="outline" className="text-xs">
+                                {resource}
+                              </Badge>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+
+                      {day.milestone ? (
+                        <div className="rounded border-l-2 border-yellow-400 bg-yellow-50 p-2 text-xs text-yellow-800">
+                          📍 {day.milestone}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/unit/Prerequisites.test.tsx
+++ b/components/unit/Prerequisites.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Prerequisites } from './Prerequisites';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('Prerequisites', () => {
+  it('renders knowledge, technology, resources, and differentiation guidance', () => {
+    const unitContent = buildUnitContent({
+      prerequisites: {
+        knowledge: ['Accounting equation'],
+        technology: ['Excel'],
+        resources: [
+          {
+            title: 'Ledger template',
+            url: 'https://example.com/template',
+            type: 'download'
+          }
+        ]
+      },
+      differentiation: {
+        struggling: ['Provide example ledger'],
+        advanced: ['Add macros'],
+        ell: ['Offer bilingual glossary']
+      }
+    });
+
+    render(
+      <Prerequisites
+        prerequisites={unitContent.prerequisites}
+        differentiation={unitContent.differentiation}
+      />
+    );
+
+    expect(screen.getByText('Accounting equation')).toBeInTheDocument();
+    expect(screen.getByText('Excel')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Ledger template/ })).toHaveAttribute(
+      'href',
+      'https://example.com/template'
+    );
+    expect(screen.getByText(/Provide example ledger/)).toBeInTheDocument();
+    expect(screen.getByText(/Add macros/)).toBeInTheDocument();
+    expect(screen.getByText(/bilingual glossary/)).toBeInTheDocument();
+  });
+
+  it('omits differentiation card when no guidance is provided', () => {
+    const unitContent = buildUnitContent({ differentiation: undefined });
+
+    render(<Prerequisites prerequisites={unitContent.prerequisites} />);
+
+    expect(screen.queryByText(/Differentiation/)).not.toBeInTheDocument();
+  });
+});

--- a/components/unit/Prerequisites.tsx
+++ b/components/unit/Prerequisites.tsx
@@ -1,0 +1,129 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type UnitDifferentiation,
+  type UnitPrerequisites,
+  type UnitResource
+} from '@/lib/db/schema/lessons';
+import { CheckSquare, Download, ExternalLink, Monitor } from 'lucide-react';
+
+interface PrerequisitesProps {
+  prerequisites: UnitPrerequisites;
+  differentiation?: UnitDifferentiation;
+}
+
+const getResourceIcon = (type: UnitResource['type']) => {
+  switch (type) {
+    case 'download':
+      return <Download className="h-4 w-4" />;
+    default:
+      return <ExternalLink className="h-4 w-4" />;
+  }
+};
+
+export function Prerequisites({ prerequisites, differentiation }: PrerequisitesProps) {
+  const renderSupportList = (label: string, items: string[], accentClass: string) =>
+    items.length ? (
+      <div>
+        <h4 className={`mb-2 font-medium ${accentClass}`}>{label}</h4>
+        <ul className="space-y-1 text-sm">
+          {items.map((item, index) => (
+            <li key={`${label}-${index}`} className="flex items-start gap-2">
+              <span className="mt-1">•</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ) : null;
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold">Prerequisites &amp; Preparation</h2>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2">
+              <CheckSquare className="h-5 w-5 text-blue-600" />
+              Before You Begin
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <h4 className="mb-2 font-medium">Required Knowledge:</h4>
+              <ul className="space-y-1 text-sm">
+                {prerequisites.knowledge.map((item, index) => (
+                  <li key={`knowledge-${index}`} className="flex items-start gap-2">
+                    <span className="mt-1 text-blue-600">•</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h4 className="mb-2 font-medium">Technology Requirements:</h4>
+              <ul className="space-y-1 text-sm">
+                {prerequisites.technology.map((item, index) => (
+                  <li key={`tech-${index}`} className="flex items-start gap-2">
+                    <Monitor className="h-4 w-4 text-blue-600" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2">
+              <Download className="h-5 w-5 text-green-600" />
+              Downloads &amp; Resources
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {prerequisites.resources.map((resource, index) => (
+              <div key={`resource-${index}`} className="flex items-center justify-between gap-4 rounded border p-2">
+                <span className="text-sm font-medium">{resource.title}</span>
+                {resource.url ? (
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="h-8"
+                    aria-label={`Open ${resource.title}`}
+                  >
+                    <a href={resource.url} target="_blank" rel="noreferrer">
+                      {getResourceIcon(resource.type)}
+                    </a>
+                  </Button>
+                ) : (
+                  <Button variant="outline" size="sm" className="h-8" disabled>
+                    {getResourceIcon(resource.type)}
+                  </Button>
+                )}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      {differentiation ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Differentiation &amp; Support</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-6 md:grid-cols-3">
+              {renderSupportList('For Struggling Students', differentiation.struggling, 'text-yellow-700')}
+              {renderSupportList('For Advanced Students', differentiation.advanced, 'text-green-700')}
+              {renderSupportList('For English Language Learners', differentiation.ell, 'text-blue-700')}
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+    </section>
+  );
+}

--- a/components/unit/StudentChoices.test.tsx
+++ b/components/unit/StudentChoices.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { StudentChoices } from './StudentChoices';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('StudentChoices', () => {
+  it('renders venture, role, and presentation sections when provided', () => {
+    const unitContent = buildUnitContent({
+      studentChoices: {
+        ventures: ['TechStart', 'Nova'],
+        roles: ['CFO'],
+        presentationFormats: ['Live demo']
+      }
+    });
+
+    render(<StudentChoices studentChoices={unitContent.studentChoices} />);
+
+    expect(screen.getByText('TechStart')).toBeInTheDocument();
+    expect(screen.getByText('CFO')).toBeInTheDocument();
+    expect(screen.getByText('Live demo')).toBeInTheDocument();
+  });
+
+  it('returns null when no options exist', () => {
+    const unitContent = buildUnitContent({ studentChoices: undefined });
+
+    const { container } = render(<StudentChoices studentChoices={unitContent.studentChoices} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/unit/StudentChoices.tsx
+++ b/components/unit/StudentChoices.tsx
@@ -1,0 +1,102 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type UnitStudentChoices } from '@/lib/db/schema/lessons';
+import { Presentation, UserCheck, Users } from 'lucide-react';
+
+interface StudentChoicesProps {
+  studentChoices?: UnitStudentChoices;
+}
+
+export function StudentChoices({ studentChoices }: StudentChoicesProps) {
+  const ventures = studentChoices?.ventures ?? [];
+  const roles = studentChoices?.roles ?? [];
+  const presentationFormats = studentChoices?.presentationFormats ?? [];
+
+  const hasContent = ventures.length || roles.length || presentationFormats.length;
+
+  if (!hasContent) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold flex items-center gap-2">
+        <Users className="h-6 w-6 text-indigo-600" />
+        Student Voice & Choice
+      </h2>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {ventures.length ? (
+          <Card className="border-indigo-200">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Badge variant="outline" className="bg-indigo-100 text-indigo-800">
+                  📈
+                </Badge>
+                Venture Selection
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-3 text-sm text-muted-foreground">
+                Choose from suggested startups or pitch your own:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {ventures.map((venture, index) => (
+                  <Badge key={`venture-${index}`} variant="outline" className="text-xs">
+                    {venture}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {roles.length ? (
+          <Card className="border-indigo-200">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <UserCheck className="h-5 w-5 text-indigo-600" />
+                Team Roles
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-3 text-sm text-muted-foreground">
+                Select a role that matches your strengths:
+              </p>
+              <div className="space-y-2">
+                {roles.map((role, index) => (
+                  <Badge key={`role-${index}`} variant="outline" className="text-xs">
+                    {role}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {presentationFormats.length ? (
+          <Card className="border-indigo-200">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Presentation className="h-5 w-5 text-indigo-600" />
+                Presentation Style
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-3 text-sm text-muted-foreground">
+                Choose how you want to showcase your work:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {presentationFormats.map((format, index) => (
+                  <Badge key={`format-${index}`} variant="outline" className="text-xs">
+                    {format}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/components/unit/UnitHeader.test.tsx
+++ b/components/unit/UnitHeader.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UnitHeader, type UnitHeaderProps } from './UnitHeader';
+
+const buildProps = (overrides: Partial<UnitHeaderProps> = {}): UnitHeaderProps => ({
+  unitNumber: 3,
+  title: 'Integrated Model Sprint',
+  description: 'Students build a full three-statement model with Sarah Chen.',
+  durationLabel: '2-3 weeks',
+  difficulty: 'advanced',
+  durationMinutes: null,
+  ...overrides
+});
+
+describe('UnitHeader', () => {
+  it('renders unit metadata with duration label and difficulty badge', () => {
+    render(<UnitHeader {...buildProps()} />);
+
+    expect(screen.getByText('Unit 3')).toBeInTheDocument();
+    expect(screen.getByText('2-3 weeks')).toBeInTheDocument();
+    expect(screen.getByText(/Integrated Model Sprint/)).toBeInTheDocument();
+    expect(screen.getByText(/Sarah Chen/)).toBeInTheDocument();
+    expect(screen.getByText(/Advanced/)).toBeInTheDocument();
+  });
+
+  it('falls back to formatted minutes when no duration label provided', () => {
+    render(
+      <UnitHeader
+        {...buildProps({
+          durationLabel: undefined,
+          durationMinutes: 90
+        })}
+      />
+    );
+
+    expect(screen.getByText('90 min')).toBeInTheDocument();
+  });
+
+  it('shows placeholder text when difficulty is missing', () => {
+    render(
+      <UnitHeader
+        {...buildProps({
+          difficulty: undefined
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Skill level TBD/i)).toBeInTheDocument();
+  });
+});

--- a/components/unit/UnitHeader.tsx
+++ b/components/unit/UnitHeader.tsx
@@ -1,0 +1,74 @@
+import { Badge } from '@/components/ui/badge';
+import { type LessonMetadata } from '@/lib/db/schema/lessons';
+import { cn } from '@/lib/utils';
+import { Clock, GraduationCap } from 'lucide-react';
+
+export interface UnitHeaderProps {
+  unitNumber: number;
+  title: string;
+  description?: string | null;
+  durationLabel?: string | null;
+  durationMinutes?: number | null;
+  difficulty?: LessonMetadata['difficulty'];
+  className?: string;
+}
+
+const difficultyConfig: Record<NonNullable<LessonMetadata['difficulty']>, { color: string; icon: string; label: string }> = {
+  beginner: { color: 'bg-green-100 text-green-800', icon: '🟢', label: 'Beginner' },
+  intermediate: { color: 'bg-yellow-100 text-yellow-800', icon: '🟡', label: 'Intermediate' },
+  advanced: { color: 'bg-red-100 text-red-800', icon: '🔴', label: 'Advanced' }
+};
+
+const formatDuration = (durationLabel?: string | null, durationMinutes?: number | null) => {
+  if (durationLabel) return durationLabel;
+  if (typeof durationMinutes === 'number' && Number.isFinite(durationMinutes)) {
+    return `${durationMinutes} min`;
+  }
+  return null;
+};
+
+export function UnitHeader({
+  unitNumber,
+  title,
+  description,
+  durationLabel,
+  durationMinutes,
+  difficulty,
+  className
+}: UnitHeaderProps) {
+  const durationText = formatDuration(durationLabel, durationMinutes);
+  const difficultyStyle = difficulty ? difficultyConfig[difficulty] : null;
+
+  return (
+    <header className={cn('space-y-4', className)}>
+      <div className="flex flex-wrap items-center gap-4 text-sm">
+        <Badge variant="default" className="bg-primary text-primary-foreground px-3 py-1">
+          {`Unit ${unitNumber}`}
+        </Badge>
+
+        {durationText ? (
+          <div className="flex items-center gap-2 text-muted-foreground" aria-label="Estimated duration">
+            <Clock className="h-4 w-4" />
+            <span>{durationText}</span>
+          </div>
+        ) : null}
+
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-4 w-4" />
+          <Badge
+            variant="outline"
+            className={difficultyStyle ? difficultyStyle.color : 'text-muted-foreground'}
+          >
+            {difficultyStyle ? `${difficultyStyle.icon} ${difficultyStyle.label}` : 'Skill level TBD'}
+          </Badge>
+        </div>
+      </div>
+
+      <h1 className="text-4xl font-bold tracking-tight">{title}</h1>
+
+      {description ? (
+        <p className="text-xl text-muted-foreground leading-relaxed max-w-4xl">{description}</p>
+      ) : null}
+    </header>
+  );
+}

--- a/components/unit/UnitIntroduction.test.tsx
+++ b/components/unit/UnitIntroduction.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UnitIntroduction } from './UnitIntroduction';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('UnitIntroduction', () => {
+  it('renders intro video, entry event, project overview, and objectives', () => {
+    const unitContent = buildUnitContent();
+
+    render(<UnitIntroduction {...unitContent.introduction!} />);
+
+    expect(screen.getByText(/Smart Ledger Launch/)).toBeInTheDocument();
+    expect(screen.getByText(/How can we build trustworthy books/)).toBeInTheDocument();
+    expect(screen.getByTitle(/Unit Kickoff/)).toBeInTheDocument();
+    expect(screen.getByText(/Entry Event/)).toBeInTheDocument();
+    expect(screen.getByText(/Angel investor diligence/)).toBeInTheDocument();
+    expect(screen.getByText(/Excel tables/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Start Learning: Core Concepts/ })).toHaveAttribute(
+      'href',
+      '#core-concepts'
+    );
+  });
+});

--- a/components/unit/UnitIntroduction.tsx
+++ b/components/unit/UnitIntroduction.tsx
@@ -1,0 +1,191 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type UnitIntroduction as UnitIntroductionData } from '@/lib/db/schema/lessons';
+import {
+  ArrowRight,
+  Clock,
+  Lightbulb,
+  PlayCircle,
+  Target,
+  Users
+} from 'lucide-react';
+
+type UnitIntroductionProps = UnitIntroductionData;
+
+const buildEmbedUrl = (youtubeId: string) =>
+  `https://www.youtube-nocookie.com/embed/${youtubeId}?rel=0&modestbranding=1`;
+
+export function UnitIntroduction({
+  unitNumber,
+  unitTitle,
+  drivingQuestion,
+  introVideo,
+  entryEvent,
+  projectOverview,
+  learningObjectives,
+  nextSectionHref = '#'
+}: UnitIntroductionProps) {
+  return (
+    <section className="space-y-8">
+      <div className="space-y-4 text-center">
+        <Badge variant="outline" className="text-sm">
+          {unitNumber} Introduction
+        </Badge>
+        <h1 className="text-4xl font-bold">{unitTitle}</h1>
+        <blockquote className="mx-auto max-w-4xl border-l-4 border-primary pl-4 text-xl italic text-muted-foreground">
+          &ldquo;{drivingQuestion}&rdquo;
+        </blockquote>
+      </div>
+
+      {introVideo ? (
+        <Card className="border-l-4 border-l-red-500">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-red-700">
+              <PlayCircle className="h-6 w-6" />
+              {introVideo.title}
+            </CardTitle>
+            {introVideo.description ? (
+              <p className="text-sm text-muted-foreground">{introVideo.description}</p>
+            ) : null}
+            {introVideo.duration ? (
+              <p className="text-xs text-muted-foreground">Duration: {introVideo.duration}</p>
+            ) : null}
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="relative aspect-video overflow-hidden rounded-lg bg-gray-100">
+              <iframe
+                src={buildEmbedUrl(introVideo.youtubeId)}
+                title={introVideo.title}
+                className="h-full w-full"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+            <details className="rounded border bg-gray-50 p-4 text-left">
+              <summary className="flex cursor-pointer items-center gap-2 font-medium">
+                <ArrowRight className="h-4 w-4" /> Video Transcript
+              </summary>
+              <pre className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">
+                {introVideo.transcript}
+              </pre>
+            </details>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card className="border-l-4 border-l-blue-500">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-blue-700">
+            <PlayCircle className="h-6 w-6" />
+            {entryEvent.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-lg leading-relaxed">{entryEvent.description}</p>
+          <div className="rounded-lg bg-blue-50 p-4">
+            <h4 className="mb-2 font-semibold text-blue-900">Day 1 Activities:</h4>
+            <ul className="space-y-2">
+              {entryEvent.activities.map((activity, index) => (
+                <li key={`entry-activity-${index}`} className="flex items-start gap-2">
+                  <ArrowRight className="h-4 w-4 flex-shrink-0 text-blue-600" />
+                  <span>{activity}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {entryEvent.resources?.length ? (
+            <div className="border-t pt-4">
+              <h5 className="mb-2 text-sm font-medium text-muted-foreground">Resources Provided:</h5>
+              <div className="flex flex-wrap gap-2">
+                {entryEvent.resources.map((resource, index) => (
+                  <Badge key={`entry-resource-${index}`} variant="secondary" className="text-xs">
+                    {resource}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card className="border-l-4 border-l-green-500">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-green-700">
+            <Target className="h-6 w-6" />
+            Your Project Challenge
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div>
+                <h4 className="mb-1 text-sm font-semibold text-muted-foreground">SCENARIO</h4>
+                <p className="text-sm">{projectOverview.scenario}</p>
+              </div>
+              <div>
+                <h4 className="mb-1 text-sm font-semibold text-muted-foreground">TEAM STRUCTURE</h4>
+                <p className="flex items-center gap-1 text-sm">
+                  <Users className="h-4 w-4" />
+                  {projectOverview.teamStructure}
+                </p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <h4 className="mb-1 text-sm font-semibold text-muted-foreground">FINAL DELIVERABLE</h4>
+                <p className="text-sm font-medium text-green-700">{projectOverview.deliverable}</p>
+              </div>
+              <div>
+                <h4 className="mb-1 text-sm font-semibold text-muted-foreground">TIMELINE</h4>
+                <p className="flex items-center gap-1 text-sm">
+                  <Clock className="h-4 w-4" />
+                  {projectOverview.timeline}
+                </p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-l-4 border-l-purple-500">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-purple-700">
+            <Lightbulb className="h-6 w-6" />
+            What You&apos;ll Learn &amp; Build
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 md:grid-cols-3">
+            {[
+              { label: 'Content Knowledge', items: learningObjectives.content },
+              { label: 'Excel Skills', items: learningObjectives.skills },
+              { label: 'Deliverables', items: learningObjectives.deliverables }
+            ].map((section, index) => (
+              <div key={`intro-objective-${index}`}>
+                <h4 className="mb-3 font-semibold text-purple-700">{section.label}</h4>
+                <ul className="space-y-2">
+                  {section.items.map((item, itemIndex) => (
+                    <li key={`objective-${index}-${itemIndex}`} className="flex items-start gap-2 text-sm">
+                      <ArrowRight className="h-3 w-3 flex-shrink-0 text-purple-500" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-center pt-8">
+        <Button asChild size="lg" className="flex items-center gap-2">
+          <a href={nextSectionHref}>
+            Start Learning: Core Concepts
+            <ArrowRight className="h-4 w-4" />
+          </a>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/components/unit/UnitOverview.test.tsx
+++ b/components/unit/UnitOverview.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UnitOverview } from './UnitOverview';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+describe('UnitOverview', () => {
+  it('lists learning objectives, skills, and deliverables', () => {
+    const unitContent = buildUnitContent({
+      objectives: {
+        content: ['Explain cash flow categories'],
+        skills: ['Use SUMIFS to reconcile data'],
+        deliverables: ['Board-ready dashboard']
+      }
+    });
+
+    render(<UnitOverview objectives={unitContent.objectives} />);
+
+    expect(screen.getByText('Explain cash flow categories')).toBeInTheDocument();
+    expect(screen.getByText('Use SUMIFS to reconcile data')).toBeInTheDocument();
+    expect(screen.getByText('Board-ready dashboard')).toBeInTheDocument();
+  });
+
+  it('shows placeholder text when a section has no items', () => {
+    const unitContent = buildUnitContent({
+      objectives: {
+        content: [],
+        skills: [],
+        deliverables: []
+      }
+    });
+
+    render(<UnitOverview objectives={unitContent.objectives} />);
+
+    expect(screen.getAllByText(/Details coming soon/i)).toHaveLength(3);
+  });
+});

--- a/components/unit/UnitOverview.tsx
+++ b/components/unit/UnitOverview.tsx
@@ -1,0 +1,66 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type UnitObjectives } from '@/lib/db/schema/lessons';
+import { BarChart3, Target, Wrench } from 'lucide-react';
+
+interface UnitOverviewProps {
+  objectives: UnitObjectives;
+}
+
+const sections = [
+  {
+    title: 'Learning Objectives',
+    icon: <Target className="h-5 w-5 text-blue-600" />,
+    key: 'content' as const,
+    accent: 'text-blue-600'
+  },
+  {
+    title: 'Tools & Skills',
+    icon: <Wrench className="h-5 w-5 text-orange-600" />,
+    key: 'skills' as const,
+    accent: 'text-orange-600'
+  },
+  {
+    title: 'Final Deliverables',
+    icon: <BarChart3 className="h-5 w-5 text-green-600" />,
+    key: 'deliverables' as const,
+    accent: 'text-green-600'
+  }
+];
+
+export function UnitOverview({ objectives }: UnitOverviewProps) {
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold">Unit Overview</h2>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {sections.map((section) => {
+          const items = objectives[section.key];
+          return (
+            <Card key={section.key}>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  {section.icon}
+                  {section.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {items.length ? (
+                  <ul className="space-y-2">
+                    {items.map((item, index) => (
+                      <li key={`${section.key}-${index}`} className="text-sm flex items-start gap-2">
+                        <span className={`${section.accent} mt-1`}>•</span>
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Details coming soon.</p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/unit/UnitTemplate.test.tsx
+++ b/components/unit/UnitTemplate.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UnitTemplate, type UnitTemplateProps } from './UnitTemplate';
+import { buildUnitContent } from '@/lib/test-utils/mock-factories';
+
+const buildProps = (overrides: Partial<UnitTemplateProps> = {}): UnitTemplateProps => ({
+  unitNumber: 1,
+  title: 'Smart Ledger Launch',
+  description: 'Students build a self-auditing ledger for Sarah Chen.',
+  durationLabel: '2-3 weeks',
+  difficulty: 'beginner',
+  durationMinutes: 90,
+  unitContent: buildUnitContent(),
+  ...overrides
+});
+
+describe('UnitTemplate', () => {
+  it('composes all sub-components with provided unit content', () => {
+    render(<UnitTemplate {...buildProps()} />);
+
+    expect(screen.getByText(/Smart Ledger Launch/)).toBeInTheDocument();
+    expect(screen.getByText(/Investor Pitch/)).toBeInTheDocument();
+    expect(screen.getByText(/Teams use TechStart data/)).toBeInTheDocument();
+    expect(screen.getByText(/Prototype ledger/)).toBeInTheDocument();
+    expect(screen.getByText(/Student Voice & Choice/)).toBeInTheDocument();
+    expect(screen.getByText(/Chromebook with Excel/)).toBeInTheDocument();
+  });
+
+  it('omits the student choice section when no options exist', () => {
+    const contentWithoutChoices = buildUnitContent({ studentChoices: undefined });
+
+    render(
+      <UnitTemplate
+        {...buildProps({
+          unitContent: contentWithoutChoices
+        })}
+      />
+    );
+
+    expect(screen.queryByText(/Student Voice & Choice/)).not.toBeInTheDocument();
+  });
+});

--- a/components/unit/UnitTemplate.tsx
+++ b/components/unit/UnitTemplate.tsx
@@ -1,0 +1,60 @@
+import { type LessonMetadata, type UnitContent } from '@/lib/db/schema/lessons';
+import { cn } from '@/lib/utils';
+
+import { AssessmentOverview } from './AssessmentOverview';
+import { DrivingQuestion } from './DrivingQuestion';
+import { LearningSequence } from './LearningSequence';
+import { Prerequisites } from './Prerequisites';
+import { StudentChoices } from './StudentChoices';
+import { UnitHeader } from './UnitHeader';
+import { UnitOverview } from './UnitOverview';
+
+export interface UnitTemplateProps {
+  unitNumber: number;
+  title: string;
+  description?: string | null;
+  durationLabel?: string | null;
+  durationMinutes?: number | null;
+  difficulty?: LessonMetadata['difficulty'];
+  unitContent: UnitContent;
+  className?: string;
+}
+
+export function UnitTemplate({
+  unitNumber,
+  title,
+  description,
+  durationLabel,
+  durationMinutes,
+  difficulty,
+  unitContent,
+  className
+}: UnitTemplateProps) {
+  return (
+    <div className={cn('space-y-12', className)}>
+      <UnitHeader
+        unitNumber={unitNumber}
+        title={title}
+        description={description}
+        durationLabel={durationLabel}
+        durationMinutes={durationMinutes}
+        difficulty={difficulty}
+      />
+
+      <UnitOverview objectives={unitContent.objectives} />
+
+      <DrivingQuestion drivingQuestion={unitContent.drivingQuestion} />
+
+      <AssessmentOverview assessment={unitContent.assessment} />
+
+      <LearningSequence learningSequence={unitContent.learningSequence} />
+
+      <StudentChoices studentChoices={unitContent.studentChoices} />
+
+      <Prerequisites
+        prerequisites={unitContent.prerequisites}
+        differentiation={unitContent.differentiation}
+      />
+    </div>
+  );
+}

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -87,3 +87,15 @@ Focused summary of learnings from Epic #2 (issues #3–#12).
 - Lesson records currently lack `unit` metadata beyond `unitNumber`, so UI helpers should accept optional unit context until the schema expands.
 - Test data factories need to stay strictly typed—allowing `PartialDeep` for nested overrides required explicitly stripping Date/content fields to keep TS + Next build happy.
 - Resource-heavy components (e.g., callout images) should standardize on `next/image` early to avoid lint churn as more legacy JSX lands in v2.
+
+## PR #27 (Issue #27) - feat/27-task-4-unit-structure-components-9-components
+
+### Highlights
+- Extended `lessonMetadataSchema` with typed unit content (objectives, assessments, prerequisites, introductions) so Supabase JSON feeds every migrated component.
+- Ported the nine legacy unit components into `components/unit/` and rewired them to accept database-shaped props with comprehensive Vitest suites.
+- Added a `buildUnitContent` factory to keep test fixtures aligned with the new Zod schema, making it easy to simulate optional metadata permutations.
+
+### Lessons
+- Unit metadata fields are only partially populated today, so components must short-circuit gracefully when optional sections like student choices or differentiation are absent.
+- Favor anchor-backed buttons instead of `window.open` to keep components server-compatible and avoid unnecessary `use client` directives.
+- Embedding introduction videos with no-JS fallbacks (iframe + `<details>` transcript) preserves accessibility while eliminating extra UI dependencies like the v1 `VideoPlayer`.

--- a/lib/db/schema/lessons.ts
+++ b/lib/db/schema/lessons.ts
@@ -1,10 +1,155 @@
 import { integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 
+const stringArray = z.array(z.string());
+
+export const unitResourceSchema = z.object({
+  title: z.string(),
+  url: z.string().url().optional(),
+  type: z.enum(['download', 'link', 'external'])
+});
+
+export const unitDrivingQuestionSchema = z.object({
+  question: z.string(),
+  context: z.string(),
+  scenario: z.string().optional()
+});
+
+export const unitObjectivesSchema = z.object({
+  content: stringArray,
+  skills: stringArray,
+  deliverables: stringArray
+});
+
+export const unitPerformanceTaskSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  requirements: stringArray,
+  context: z.string().optional()
+});
+
+export const unitMilestoneSchema = z.object({
+  id: z.string(),
+  day: z.number(),
+  title: z.string(),
+  description: z.string(),
+  criteria: stringArray
+});
+
+export const unitRubricCriteriaSchema = z.object({
+  name: z.string(),
+  weight: z.string(),
+  exemplary: z.string(),
+  proficient: z.string(),
+  developing: z.string()
+});
+
+export const unitAssessmentSchema = z.object({
+  performanceTask: unitPerformanceTaskSchema,
+  milestones: z.array(unitMilestoneSchema),
+  rubric: z.array(unitRubricCriteriaSchema)
+});
+
+export const unitLearningSequenceDaySchema = z.object({
+  day: z.number(),
+  focus: z.string(),
+  activities: stringArray,
+  resources: stringArray,
+  milestone: z.string().optional()
+});
+
+export const unitLearningSequenceWeekSchema = z.object({
+  weekNumber: z.number(),
+  title: z.string(),
+  description: z.string(),
+  days: z.array(unitLearningSequenceDaySchema)
+});
+
+export const unitLearningSequenceSchema = z.object({
+  weeks: z.array(unitLearningSequenceWeekSchema)
+});
+
+export const unitStudentChoicesSchema = z.object({
+  ventures: stringArray.optional(),
+  roles: stringArray.optional(),
+  presentationFormats: stringArray.optional()
+});
+
+export const unitPrerequisitesSchema = z.object({
+  knowledge: stringArray,
+  technology: stringArray,
+  resources: z.array(unitResourceSchema)
+});
+
+export const unitDifferentiationSchema = z.object({
+  struggling: stringArray.default([]),
+  advanced: stringArray.default([]),
+  ell: stringArray.default([])
+});
+
+const videoContentSchema = z.object({
+  youtubeId: z.string(),
+  title: z.string(),
+  duration: z.string().optional(),
+  description: z.string().optional(),
+  transcript: z.string()
+});
+
+const unitEntryEventSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  activities: stringArray,
+  resources: stringArray.optional()
+});
+
+const unitProjectOverviewSchema = z.object({
+  scenario: z.string(),
+  teamStructure: z.string(),
+  deliverable: z.string(),
+  timeline: z.string()
+});
+
+export const unitIntroductionSchema = z.object({
+  unitNumber: z.string(),
+  unitTitle: z.string(),
+  drivingQuestion: z.string(),
+  introVideo: videoContentSchema.optional(),
+  entryEvent: unitEntryEventSchema,
+  projectOverview: unitProjectOverviewSchema,
+  learningObjectives: unitObjectivesSchema,
+  nextSectionHref: z.string().optional()
+});
+
+export const unitContentSchema = z.object({
+  drivingQuestion: unitDrivingQuestionSchema,
+  objectives: unitObjectivesSchema,
+  assessment: unitAssessmentSchema,
+  learningSequence: unitLearningSequenceSchema,
+  studentChoices: unitStudentChoicesSchema.optional(),
+  prerequisites: unitPrerequisitesSchema,
+  differentiation: unitDifferentiationSchema.optional(),
+  introduction: unitIntroductionSchema.optional()
+});
+
+export type UnitResource = z.infer<typeof unitResourceSchema>;
+export type UnitDrivingQuestion = z.infer<typeof unitDrivingQuestionSchema>;
+export type UnitObjectives = z.infer<typeof unitObjectivesSchema>;
+export type UnitAssessment = z.infer<typeof unitAssessmentSchema>;
+export type UnitMilestone = z.infer<typeof unitMilestoneSchema>;
+export type UnitRubricCriteria = z.infer<typeof unitRubricCriteriaSchema>;
+export type UnitLearningSequence = z.infer<typeof unitLearningSequenceSchema>;
+export type UnitStudentChoices = z.infer<typeof unitStudentChoicesSchema>;
+export type UnitPrerequisites = z.infer<typeof unitPrerequisitesSchema>;
+export type UnitDifferentiation = z.infer<typeof unitDifferentiationSchema>;
+export type UnitIntroduction = z.infer<typeof unitIntroductionSchema>;
+export type UnitContent = z.infer<typeof unitContentSchema>;
+
 export const lessonMetadataSchema = z.object({
   duration: z.number().optional(),
+  durationLabel: z.string().optional(),
   difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
   tags: z.array(z.string()).optional(),
+  unitContent: unitContentSchema.optional()
 });
 
 export type LessonMetadata = z.infer<typeof lessonMetadataSchema>;
@@ -21,4 +166,3 @@ export const lessons = pgTable('lessons', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
-

--- a/lib/test-utils/mock-factories.ts
+++ b/lib/test-utils/mock-factories.ts
@@ -54,6 +54,10 @@ import {
   type SessionLeaderboardEntry,
   type StudentProgress
 } from '@/lib/db/schema/validators';
+import {
+  unitContentSchema,
+  type UnitContent
+} from '@/lib/db/schema/lessons';
 
 const now = () => new Date();
 
@@ -121,6 +125,130 @@ export function createPhase(overrides: Partial<Phase> = {}): Phase {
     updatedAt: overrides.updatedAt ?? now()
   };
   return selectPhaseSchema.parse(payload);
+}
+
+export function buildUnitContent(overrides: Partial<UnitContent> = {}): UnitContent {
+  const hasOverride = <K extends keyof UnitContent>(key: K) =>
+    Object.prototype.hasOwnProperty.call(overrides, key);
+
+  const payload: UnitContent = {
+    drivingQuestion: {
+      question: 'How can we build a reliable financial model?',
+      context: 'Teams use TechStart data to design a classroom-ready playbook.',
+      scenario: "Serve as Sarah Chen's student analyst team.",
+      ...(overrides.drivingQuestion ?? {})
+    },
+    objectives: {
+      content: ['Explain the accounting equation'],
+      skills: ['Create SUMIF based ledgers'],
+      deliverables: ['Investor-ready ledger workbook'],
+      ...(overrides.objectives ?? {})
+    },
+    assessment: {
+      performanceTask: {
+        title: 'Investor Pitch',
+        description: 'Present the completed workbook to the TechStart board.',
+        requirements: ['4-minute presentation', 'Live Excel demonstration'],
+        context: 'Students mirror real diligence conversations',
+        ...(overrides.assessment?.performanceTask ?? {})
+      },
+      milestones: overrides.assessment?.milestones ?? [
+        {
+          id: 'milestone-1',
+          day: 3,
+          title: 'Prototype ledger',
+          description: 'Record first 10 transactions',
+          criteria: ['Debits equal credits', 'Transactions categorized']
+        }
+      ],
+      rubric: overrides.assessment?.rubric ?? [
+        {
+          name: 'Accuracy',
+          weight: '40%',
+          exemplary: 'Flawless records, zero balancing errors',
+          proficient: 'Minor calculation errors',
+          developing: 'Frequent calculation errors'
+        }
+      ]
+    },
+    learningSequence: overrides.learningSequence ?? {
+      weeks: [
+        {
+          weekNumber: 1,
+          title: 'Ledger Foundations',
+          description: 'Establish baseline knowledge',
+          days: [
+            {
+              day: 1,
+              focus: 'Launch + Story',
+              activities: ["Watch Sarah's story"],
+              resources: ['Unit overview PDF'],
+              milestone: 'Understand project scope'
+            }
+          ]
+        }
+      ]
+    },
+    studentChoices: hasOverride('studentChoices')
+      ? overrides.studentChoices
+      : {
+        ventures: ['TechStart'],
+        roles: ['CFO'],
+        presentationFormats: ['Live demo']
+      },
+    prerequisites: overrides.prerequisites ?? {
+      knowledge: ['Accounting equation basics'],
+      technology: ['Chromebook with Excel'],
+      resources: [
+        {
+          title: 'Ledger template',
+          url: 'https://example.com/template',
+          type: 'download'
+        }
+      ]
+    },
+    differentiation: hasOverride('differentiation')
+      ? overrides.differentiation
+      : {
+        struggling: ['Provide annotated exemplars'],
+        advanced: ['Add an automation macro'],
+        ell: ['Pair with bilingual teammate']
+      },
+    introduction: hasOverride('introduction')
+      ? overrides.introduction
+      : {
+        unitNumber: 'Unit 1',
+        unitTitle: 'Smart Ledger Launch',
+        drivingQuestion: 'How can we build trustworthy books?',
+      introVideo: {
+        youtubeId: 'dQw4w9WgXcQ',
+        title: 'Unit Kickoff',
+        duration: '05:00',
+        description: 'Overview of the capstone challenge',
+        transcript: 'Welcome to the challenge...'
+      },
+      entryEvent: {
+        title: 'Entry Event',
+        description: 'Scenario briefing and initial tasks',
+        activities: ['Pitch analysis', 'Team formation'],
+        resources: ['Briefing deck']
+      },
+      projectOverview: {
+        scenario: 'Angel investor diligence',
+        teamStructure: 'Teams of 3',
+        deliverable: 'Demo-ready workbook',
+        timeline: '2 weeks'
+      },
+      learningObjectives: {
+        content: ['Balance sheets basics'],
+        skills: ['Excel tables'],
+        deliverables: ['Pitch deck outline']
+      },
+      nextSectionHref: '#core-concepts'
+    }
+  };
+
+  return unitContentSchema.parse(payload);
 }
 
 export function buildActivityInput(overrides: Partial<NewActivity> = {}): NewActivity {


### PR DESCRIPTION
## Summary
- migrate the nine unit structure components from v1 to v2
- extend lesson metadata with typed unit content and add test factories
- add Vitest coverage for each component and document in retrospective

## Testing
- npm run test
- npm run lint
- npm run build