### PR TITLE
feat: migrate drag-drop exercises part 2a

### DIFF
--- a/components/drag-drop-exercises/AccountCategorization.test.tsx
+++ b/components/drag-drop-exercises/AccountCategorization.test.tsx
@@ -1,0 +1,84 @@
+import { triggerDrag } from '@/lib/test-utils/mock-dnd';
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DropResult } from '@hello-pangea/dnd';
+
+import { AccountCategorization, type AccountCategorizationActivity } from './AccountCategorization';
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId
+} from './useCategorizationExercise';
+import type { AccountCategorizationActivityProps } from '@/lib/db/schema/activities';
+
+const buildActivity = (overrides: Partial<AccountCategorizationActivityProps> = {}): AccountCategorizationActivity => ({
+  id: 'activity-account',
+  componentKey: 'account-categorization',
+  displayName: 'Account Categorization',
+  description: 'Sort accounts',
+  props: {
+    title: 'Categorize accounts',
+    description: 'Match each account to the right category',
+    categories: [
+      { id: 'assets', name: 'Assets', description: 'Things we own', emoji: '💰' },
+      { id: 'expenses', name: 'Expenses', description: 'Costs we pay', emoji: '💸' }
+    ],
+    accounts: [
+      {
+        id: 'acct-cash',
+        name: 'Cash',
+        description: 'Money on hand',
+        categoryId: 'assets'
+      },
+      {
+        id: 'acct-rent',
+        name: 'Rent Expense',
+        description: 'Monthly rent',
+        categoryId: 'expenses'
+      }
+    ],
+    showHintsByDefault: false,
+    shuffleItems: false,
+    ...overrides
+  },
+  gradingConfig: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+});
+
+const performDrop = (itemId: string, zoneId: string) =>
+  act(() => {
+    triggerDrag({
+      draggableId: itemId,
+      type: 'DEFAULT',
+      source: { droppableId: AVAILABLE_ITEMS_DROPPABLE, index: 0 },
+      destination: { droppableId: getZoneDroppableId(zoneId), index: 0 },
+      reason: 'DROP',
+      mode: 'FLUID',
+      combine: null
+    } as DropResult);
+  });
+
+describe('AccountCategorization', () => {
+  it('calls onSubmit when all accounts are categorized correctly', async () => {
+    const onSubmit = vi.fn();
+    render(<AccountCategorization activity={buildActivity()} onSubmit={onSubmit} />);
+
+    performDrop('acct-cash', 'assets');
+    performDrop('acct-rent', 'expenses');
+
+    expect(await screen.findByText(/Score: 100%/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activityId: 'activity-account',
+          score: 100,
+          responses: {
+            assets: ['acct-cash'],
+            expenses: ['acct-rent']
+          }
+        })
+      );
+    });
+  });
+});

--- a/components/drag-drop-exercises/AccountCategorization.tsx
+++ b/components/drag-drop-exercises/AccountCategorization.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import { HelpCircle, RotateCcw, Target } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import type { Activity } from '@/lib/db/schema/validators';
+import { type AccountCategorizationActivityProps } from '@/lib/db/schema/activities';
+
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId,
+  useCategorizationExercise,
+  type CategorizationItem
+} from './useCategorizationExercise';
+
+export type AccountCategorizationActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'account-categorization';
+  props: AccountCategorizationActivityProps;
+};
+
+interface AccountCategorizationProps {
+  activity: AccountCategorizationActivity;
+  onSubmit?: (payload: {
+    activityId: string;
+    score: number;
+    attempts: number;
+    responses: Record<string, string[]>;
+    completedAt: Date;
+  }) => void;
+}
+
+type AccountItem = AccountCategorizationActivityProps['accounts'][number] & CategorizationItem;
+
+export function AccountCategorization({ activity, onSubmit }: AccountCategorizationProps) {
+  const [showHints, setShowHints] = useState(activity.props.showHintsByDefault);
+
+  const categories = activity.props.categories;
+  const zoneIds = useMemo(() => categories.map((category) => category.id), [categories]);
+  const items = useMemo<AccountItem[]>(
+    () =>
+      activity.props.accounts.map((account) => ({
+        ...account,
+        targetId: account.categoryId
+      })),
+    [activity.props.accounts]
+  );
+
+  const handleCompletion = useCallback(
+    ({ score, attempts, placements }: { score: number; attempts: number; placements: Record<string, AccountItem[]> }) => {
+      const responses = Object.fromEntries(
+        Object.entries(placements).map(([zoneId, zoneItems]) => [zoneId, zoneItems.map((item) => item.id)])
+      );
+      onSubmit?.({
+        activityId: activity.id,
+        score,
+        attempts,
+        responses,
+        completedAt: new Date()
+      });
+    },
+    [activity.id, onSubmit]
+  );
+
+  const { availableItems, placements, attempts, score, completed, handleDragEnd, reset } = useCategorizationExercise(items, zoneIds, {
+    shuffleItems: activity.props.shuffleItems,
+    resetKey: activity.id,
+    onComplete: handleCompletion
+  });
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle className="text-2xl">{activity.props.title}</CardTitle>
+          <CardDescription>{activity.props.description ?? activity.description}</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Badge variant="secondary" className="flex items-center gap-2">
+            <Target className="h-4 w-4" />
+            Score: {score}%
+          </Badge>
+          <Badge variant="outline">Attempts: {attempts}</Badge>
+          {completed && <Badge variant="default">Completed 🎉</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <label className="inline-flex items-center gap-2">
+            <input type="checkbox" checked={showHints} onChange={() => setShowHints((prev) => !prev)} className="h-4 w-4" />
+            Show context hints
+          </label>
+          <div className="inline-flex items-center gap-2">
+            <HelpCircle className="h-4 w-4" />
+            Drag each account into the correct category to reinforce the accounting equation.
+          </div>
+        </div>
+
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="grid gap-6 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase text-muted-foreground">Account bank</h3>
+                <Button variant="ghost" size="sm" onClick={reset} className="gap-2 text-xs">
+                  <RotateCcw className="h-4 w-4" />
+                  Reset
+                </Button>
+              </div>
+              <Droppable droppableId={AVAILABLE_ITEMS_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/70 p-3 min-h-[200px]"
+                  >
+                    {availableItems.map((item, index) => (
+                      <Draggable key={item.id} draggableId={item.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            {...dragProvided.dragHandleProps}
+                            className={cn(
+                              'rounded-lg border bg-card p-3 shadow-sm transition',
+                              snapshot.isDragging && 'ring-2 ring-primary'
+                            )}
+                          >
+                            <p className="font-semibold">{item.name}</p>
+                            <p className="text-sm text-muted-foreground">{item.description}</p>
+                            {showHints && item.realWorldExample && (
+                              <p className="mt-2 text-xs text-muted-foreground/80">Example: {item.realWorldExample}</p>
+                            )}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    {availableItems.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">All accounts placed. Adjust if needed!</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </section>
+
+            <section className="space-y-4">
+              {categories.map((category) => (
+                <div key={category.id} className="rounded-xl border bg-muted/10 p-4">
+                  <div className="flex flex-col gap-1 pb-3">
+                    <div className="flex items-center gap-2">
+                      <p className="text-lg font-semibold">
+                        {category.emoji} {category.name}
+                      </p>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{category.description}</p>
+                    {showHints && category.whyItMatters && (
+                      <p className="text-xs text-muted-foreground/80">Why it matters: {category.whyItMatters}</p>
+                    )}
+                  </div>
+                  <Separator />
+                  <Droppable droppableId={getZoneDroppableId(category.id)}>
+                    {(provided) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className="mt-3 flex flex-col gap-3 rounded-lg border border-dashed bg-background/60 p-3 min-h-[120px]"
+                      >
+                        {placements[category.id]?.map((item, index) => {
+                          const isCorrect = item.targetId === category.id;
+                          return (
+                            <Draggable key={item.id} draggableId={item.id} index={index}>
+                              {(dragProvided, snapshot) => (
+                                <div
+                                  ref={dragProvided.innerRef}
+                                  {...dragProvided.draggableProps}
+                                  {...dragProvided.dragHandleProps}
+                                  className={cn(
+                                    'rounded-lg border bg-card p-3 transition',
+                                    attempts > 0 && (isCorrect ? 'border-green-500 bg-green-50' : 'border-destructive bg-destructive/10'),
+                                    snapshot.isDragging && 'ring-2 ring-primary'
+                                  )}
+                                >
+                                  <p className="font-medium">{item.name}</p>
+                                  <p className="text-sm text-muted-foreground">{item.description}</p>
+                                  {showHints && item.realWorldExample && (
+                                    <p className="mt-1 text-xs text-muted-foreground/80">Real-world: {item.realWorldExample}</p>
+                                  )}
+                                </div>
+                              )}
+                            </Draggable>
+                          );
+                        })}
+                        {provided.placeholder}
+                        {placements[category.id]?.length === 0 && (
+                          <p className="text-xs text-muted-foreground text-center">Drop accounts here</p>
+                        )}
+                      </div>
+                    )}
+                  </Droppable>
+                </div>
+              ))}
+            </section>
+          </div>
+        </DragDropContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/drag-drop-exercises/BudgetCategorySort.test.tsx
+++ b/components/drag-drop-exercises/BudgetCategorySort.test.tsx
@@ -1,0 +1,87 @@
+import { triggerDrag } from '@/lib/test-utils/mock-dnd';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DropResult } from '@hello-pangea/dnd';
+
+import { BudgetCategorySort, type BudgetCategorySortActivity } from './BudgetCategorySort';
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId
+} from './useCategorizationExercise';
+import type { BudgetCategorySortActivityProps } from '@/lib/db/schema/activities';
+
+const buildActivity = (overrides: Partial<BudgetCategorySortActivityProps> = {}): BudgetCategorySortActivity => ({
+  id: 'activity-budget',
+  componentKey: 'budget-category-sort',
+  displayName: 'Budget Sort',
+  description: 'Sort expenses',
+  props: {
+    title: 'Sort café expenses',
+    description: 'Place each expense in the right budget category',
+    categories: [
+      { id: 'labor', title: 'Labor', description: 'Staff costs', emoji: '🧑‍🍳' },
+      { id: 'overhead', title: 'Overhead', description: 'Fixed costs', emoji: '🏢' }
+    ],
+    expenses: [
+      {
+        id: 'expense-wages',
+        label: 'Barista wages',
+        description: 'Hourly pay for staff',
+        amount: 3000,
+        categoryId: 'labor',
+        impact: 'high'
+      },
+      {
+        id: 'expense-rent',
+        label: 'Rent',
+        description: 'Monthly lease',
+        amount: 2000,
+        categoryId: 'overhead',
+        impact: 'medium'
+      }
+    ],
+    showHintsByDefault: false,
+    shuffleItems: false,
+    ...overrides
+  },
+  gradingConfig: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+});
+
+const dropExpense = (itemId: string, zoneId: string) =>
+  act(() => {
+    triggerDrag({
+      draggableId: itemId,
+      type: 'DEFAULT',
+      source: { droppableId: AVAILABLE_ITEMS_DROPPABLE, index: 0 },
+      destination: { droppableId: getZoneDroppableId(zoneId), index: 0 },
+      reason: 'DROP',
+      mode: 'FLUID',
+      combine: null
+    } as DropResult);
+  });
+
+describe('BudgetCategorySort', () => {
+  it('submits categorized expenses', async () => {
+    const onSubmit = vi.fn();
+    render(<BudgetCategorySort activity={buildActivity()} onSubmit={onSubmit} />);
+
+    dropExpense('expense-wages', 'labor');
+    dropExpense('expense-rent', 'overhead');
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activityId: 'activity-budget',
+          score: 100,
+          responses: {
+            labor: ['expense-wages'],
+            overhead: ['expense-rent']
+          }
+        })
+      );
+    });
+  });
+});

--- a/components/drag-drop-exercises/BudgetCategorySort.tsx
+++ b/components/drag-drop-exercises/BudgetCategorySort.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import { DollarSign, Lightbulb, RotateCcw } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { Activity } from '@/lib/db/schema/validators';
+import { type BudgetCategorySortActivityProps } from '@/lib/db/schema/activities';
+
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId,
+  useCategorizationExercise,
+  type CategorizationItem
+} from './useCategorizationExercise';
+
+export type BudgetCategorySortActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'budget-category-sort';
+  props: BudgetCategorySortActivityProps;
+};
+
+interface BudgetCategorySortProps {
+  activity: BudgetCategorySortActivity;
+  onSubmit?: (payload: {
+    activityId: string;
+    score: number;
+    attempts: number;
+    responses: Record<string, string[]>;
+    completedAt: Date;
+  }) => void;
+}
+
+type BudgetItem = BudgetCategorySortActivityProps['expenses'][number] & CategorizationItem;
+
+const impactBadge = (impact: BudgetItem['impact']) => {
+  switch (impact) {
+    case 'high':
+      return 'destructive';
+    case 'low':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+};
+
+export function BudgetCategorySort({ activity, onSubmit }: BudgetCategorySortProps) {
+  const [showHints, setShowHints] = useState(activity.props.showHintsByDefault);
+
+  const categories = activity.props.categories;
+  const zoneIds = useMemo(() => categories.map((category) => category.id), [categories]);
+  const items = useMemo<BudgetItem[]>(
+    () =>
+      activity.props.expenses.map((expense) => ({
+        ...expense,
+        targetId: expense.categoryId
+      })),
+    [activity.props.expenses]
+  );
+
+  const handleCompletion = useCallback(
+    ({ score, attempts, placements }: { score: number; attempts: number; placements: Record<string, BudgetItem[]> }) => {
+      const responses = Object.fromEntries(
+        Object.entries(placements).map(([zoneId, zoneItems]) => [zoneId, zoneItems.map((item) => item.id)])
+      );
+      onSubmit?.({
+        activityId: activity.id,
+        score,
+        attempts,
+        responses,
+        completedAt: new Date()
+      });
+    },
+    [activity.id, onSubmit]
+  );
+
+  const { availableItems, placements, attempts, score, completed, handleDragEnd, reset } = useCategorizationExercise(items, zoneIds, {
+    shuffleItems: activity.props.shuffleItems,
+    resetKey: activity.id,
+    onComplete: handleCompletion
+  });
+
+  const totalBudgetPlaced = useMemo(
+    () =>
+      Object.values(placements).flat().reduce((sum, expense) => {
+        return sum + expense.amount;
+      }, 0),
+    [placements]
+  );
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle className="text-2xl">{activity.props.title}</CardTitle>
+          <CardDescription>{activity.props.description ?? activity.description}</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Badge variant="secondary" className="flex items-center gap-2">
+            <DollarSign className="h-4 w-4" />
+            Placed budget: ${totalBudgetPlaced.toLocaleString()}
+          </Badge>
+          <Badge variant="outline">Score: {score}%</Badge>
+          <Badge variant="outline">Attempts: {attempts}</Badge>
+          {completed && <Badge variant="default">Completed</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <label className="inline-flex items-center gap-2">
+            <input type="checkbox" checked={showHints} onChange={() => setShowHints((prev) => !prev)} className="h-4 w-4" />
+            Show budgeting hints
+          </label>
+          <div className="inline-flex items-center gap-2">
+            <Lightbulb className="h-4 w-4" />
+            Match each café expense to the budget category it belongs to.
+          </div>
+        </div>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="grid gap-6 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase text-muted-foreground">Expense pool</h3>
+                <Button variant="ghost" size="sm" onClick={reset} className="gap-2 text-xs">
+                  <RotateCcw className="h-4 w-4" />
+                  Reset
+                </Button>
+              </div>
+              <Droppable droppableId={AVAILABLE_ITEMS_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/70 p-3 min-h-[200px]"
+                  >
+                    {availableItems.map((item, index) => (
+                      <Draggable key={item.id} draggableId={item.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            {...dragProvided.dragHandleProps}
+                            className={cn(
+                              'rounded-lg border bg-card p-3 transition',
+                              snapshot.isDragging && 'ring-2 ring-primary'
+                            )}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="font-semibold">{item.label}</p>
+                              <Badge variant={impactBadge(item.impact)}>${item.amount.toLocaleString()}</Badge>
+                            </div>
+                            <p className="text-sm text-muted-foreground">{item.description}</p>
+                            {showHints && item.cafeContext && (
+                              <p className="mt-2 text-xs text-muted-foreground/80">{item.cafeContext}</p>
+                            )}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    {availableItems.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">All expenses are categorized—great work!</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </section>
+
+            <section className="space-y-4">
+              {categories.map((category) => (
+                <div key={category.id} className="rounded-xl border bg-muted/10 p-4">
+                  <div className="flex flex-col gap-1 pb-3">
+                    <div className="flex items-center gap-2">
+                      <p className="text-lg font-semibold">{category.emoji} {category.title}</p>
+                      {category.profitImpact && <Badge variant="secondary">{category.profitImpact}</Badge>}
+                    </div>
+                    <p className="text-sm text-muted-foreground">{category.description}</p>
+                    {showHints && category.strategyNote && (
+                      <p className="text-xs text-muted-foreground/80">Hint: {category.strategyNote}</p>
+                    )}
+                  </div>
+                  <Droppable droppableId={getZoneDroppableId(category.id)}>
+                    {(provided) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className="mt-2 flex flex-col gap-3 rounded-lg border border-dashed bg-background/60 p-3 min-h-[120px]"
+                      >
+                        {(placements[category.id] ?? []).map((item, index) => {
+                          const isCorrect = item.targetId === category.id;
+                          return (
+                            <Draggable key={item.id} draggableId={item.id} index={index}>
+                              {(dragProvided, snapshot) => (
+                                <div
+                                  ref={dragProvided.innerRef}
+                                  {...dragProvided.draggableProps}
+                                  {...dragProvided.dragHandleProps}
+                                  className={cn(
+                                    'rounded-lg border bg-card p-3 transition',
+                                    attempts > 0 && (isCorrect ? 'border-green-500 bg-green-50' : 'border-destructive bg-destructive/10'),
+                                    snapshot.isDragging && 'ring-2 ring-primary'
+                                  )}
+                                >
+                                  <div className="flex items-center justify-between gap-2">
+                                    <p className="font-medium">{item.label}</p>
+                                    <Badge variant="outline">${item.amount.toLocaleString()}</Badge>
+                                  </div>
+                                  <p className="text-xs text-muted-foreground">{item.description}</p>
+                                </div>
+                              )}
+                            </Draggable>
+                          );
+                        })}
+                        {provided.placeholder}
+                        {(placements[category.id] ?? []).length === 0 && (
+                          <p className="text-xs text-muted-foreground text-center">Drop expenses here</p>
+                        )}
+                      </div>
+                    )}
+                  </Droppable>
+                  <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Total</span>
+                    <span>
+                      $
+                      {(placements[category.id] ?? [])
+                        .reduce((sum, expense) => sum + expense.amount, 0)
+                        .toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </section>
+          </div>
+        </DragDropContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/drag-drop-exercises/InventoryFlowDiagram.test.tsx
+++ b/components/drag-drop-exercises/InventoryFlowDiagram.test.tsx
@@ -1,0 +1,88 @@
+import { dragHandlers, triggerDrag } from '@/lib/test-utils/mock-dnd';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DropResult } from '@hello-pangea/dnd';
+
+import {
+  InventoryFlowDiagram,
+  INVENTORY_ARRANGEMENT_DROPPABLE,
+  INVENTORY_AVAILABLE_DROPPABLE,
+  type InventoryFlowDiagramActivity
+} from './InventoryFlowDiagram';
+import type { InventoryFlowDiagramActivityProps } from '@/lib/db/schema/activities';
+
+const buildActivity = (
+  overrides: Partial<InventoryFlowDiagramActivityProps> = {}
+): InventoryFlowDiagramActivity => ({
+  id: 'activity-inventory',
+  componentKey: 'inventory-flow-diagram',
+  displayName: 'Inventory Flow',
+  description: 'Arrange lots',
+  props: {
+    title: 'Inventory flow',
+    description: 'Arrange lots to match FIFO/LIFO',
+    scenarios: [
+      {
+        id: 'scenario-1',
+        title: 'Laptop lots',
+        description: 'Organize laptop purchases',
+        context: 'Tech retail pilot',
+        salesQuantity: 10,
+        lots: [
+          { id: 'lot-a', label: 'January lot', purchaseDate: '2024-01-01', quantity: 5, unitCost: 1000 },
+          { id: 'lot-b', label: 'February lot', purchaseDate: '2024-02-01', quantity: 5, unitCost: 1100 }
+        ],
+        flowModes: [
+          {
+            id: 'fifo',
+            name: 'FIFO',
+            description: 'Oldest inventory first',
+            targetOrder: ['lot-a', 'lot-b']
+          }
+        ]
+      }
+    ],
+    ...overrides
+  },
+  gradingConfig: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+});
+
+const moveLot = (lotId: string, sourceIndex: number, destinationIndex: number) =>
+  act(() => {
+    triggerDrag({
+      draggableId: lotId,
+      type: 'DEFAULT',
+      source: { droppableId: INVENTORY_AVAILABLE_DROPPABLE, index: sourceIndex },
+      destination: { droppableId: INVENTORY_ARRANGEMENT_DROPPABLE, index: destinationIndex },
+      reason: 'DROP',
+      mode: 'FLUID',
+      combine: null
+    } as DropResult);
+  });
+
+describe('InventoryFlowDiagram', () => {
+  it('submits once the arrangement matches the target order', async () => {
+    const onSubmit = vi.fn();
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    render(<InventoryFlowDiagram activity={buildActivity()} onSubmit={onSubmit} />);
+    expect(dragHandlers.onDragEnd).toBeTruthy();
+
+    moveLot('lot-a', 0, 0);
+    moveLot('lot-b', 0, 1);
+
+    expect(await screen.findByText(/Step 1: January lot/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Step 2: February lot/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Flow complete/i)).toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activityId: 'activity-inventory',
+        responses: { arrangement: ['lot-a', 'lot-b'] }
+      })
+    );
+    randomSpy.mockRestore();
+  });
+});

--- a/components/drag-drop-exercises/InventoryFlowDiagram.tsx
+++ b/components/drag-drop-exercises/InventoryFlowDiagram.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
+import { ArrowRight, BarChart3, Package, RotateCcw, Warehouse } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import type { Activity } from '@/lib/db/schema/validators';
+import { type InventoryFlowDiagramActivityProps } from '@/lib/db/schema/activities';
+
+export type InventoryFlowDiagramActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'inventory-flow-diagram';
+  props: InventoryFlowDiagramActivityProps;
+};
+
+interface InventoryFlowDiagramProps {
+  activity: InventoryFlowDiagramActivity;
+  onSubmit?: (payload: {
+    activityId: string;
+    score: number;
+    attempts: number;
+    responses: Record<string, string[]>;
+    completedAt: Date;
+  }) => void;
+}
+
+type InventoryScenario = InventoryFlowDiagramActivityProps['scenarios'][number];
+type InventoryLot = InventoryScenario['lots'][number];
+
+export const INVENTORY_AVAILABLE_DROPPABLE = 'inventory-available';
+export const INVENTORY_ARRANGEMENT_DROPPABLE = 'inventory-arrangement';
+
+export function InventoryFlowDiagram({ activity, onSubmit }: InventoryFlowDiagramProps) {
+  const scenarios = activity.props.scenarios;
+  const [scenarioId, setScenarioId] = useState(scenarios[0]?.id ?? '');
+
+  const activeScenario = useMemo<InventoryScenario>(
+    () => scenarios.find((scenario) => scenario.id === scenarioId) ?? scenarios[0],
+    [scenarioId, scenarios]
+  );
+
+  const [methodId, setMethodId] = useState(activeScenario?.flowModes[0]?.id ?? '');
+
+  useEffect(() => {
+    if (!activeScenario) return;
+    setMethodId(activeScenario.flowModes[0]?.id ?? '');
+  }, [activeScenario]);
+
+  const activeMode = useMemo(
+    () => activeScenario?.flowModes.find((mode) => mode.id === methodId) ?? activeScenario?.flowModes[0],
+    [activeScenario, methodId]
+  );
+
+  const [availableLots, setAvailableLots] = useState<InventoryLot[]>([]);
+  const [arrangement, setArrangement] = useState<InventoryLot[]>([]);
+  const [attempts, setAttempts] = useState(0);
+  const [score, setScore] = useState(0);
+  const [completed, setCompleted] = useState(false);
+
+  const resetBoard = useCallback(() => {
+    if (!activeScenario) return;
+    setAvailableLots([...activeScenario.lots].sort(() => Math.random() - 0.5));
+    setArrangement([]);
+    setAttempts(0);
+    setScore(0);
+    setCompleted(false);
+  }, [activeScenario]);
+
+  useEffect(() => {
+    resetBoard();
+  }, [resetBoard, activeMode]);
+
+  const evaluate = useCallback(
+    (nextArrangement: InventoryLot[], upcomingAttempts: number) => {
+      if (!activeMode) return;
+      const targetOrder = activeMode.targetOrder;
+      const comparableLength = Math.min(targetOrder.length, nextArrangement.length);
+      let correct = 0;
+      for (let i = 0; i < comparableLength; i += 1) {
+        if (nextArrangement[i]?.id === targetOrder[i]) {
+          correct += 1;
+        }
+      }
+      const nextScore = targetOrder.length === 0 ? 0 : Math.round((correct / targetOrder.length) * 100);
+      setScore(nextScore);
+
+      if (!completed && targetOrder.length > 0 && correct === targetOrder.length) {
+        setCompleted(true);
+        onSubmit?.({
+          activityId: activity.id,
+          score: nextScore,
+          attempts: upcomingAttempts,
+          responses: { arrangement: nextArrangement.map((lot) => lot.id) },
+          completedAt: new Date()
+        });
+      }
+    },
+    [activity.id, activeMode, completed, onSubmit]
+  );
+
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      const { source, destination } = result;
+      if (!destination) return;
+      if (destination.droppableId === source.droppableId && destination.index === source.index) return;
+
+      const nextAvailable = [...availableLots];
+      const nextArrangement = [...arrangement];
+      let movingLot: InventoryLot | undefined;
+
+      if (source.droppableId === INVENTORY_AVAILABLE_DROPPABLE) {
+        movingLot = nextAvailable.splice(source.index, 1)[0];
+      } else if (source.droppableId === INVENTORY_ARRANGEMENT_DROPPABLE) {
+        movingLot = nextArrangement.splice(source.index, 1)[0];
+      }
+
+      if (!movingLot) return;
+
+      if (destination.droppableId === INVENTORY_AVAILABLE_DROPPABLE) {
+        nextAvailable.splice(destination.index, 0, movingLot);
+      } else if (destination.droppableId === INVENTORY_ARRANGEMENT_DROPPABLE) {
+        nextArrangement.splice(destination.index, 0, movingLot);
+      } else {
+        return;
+      }
+
+      setAvailableLots(nextAvailable);
+      setArrangement(nextArrangement);
+      setAttempts((prev) => {
+        const upcomingAttempts = prev + 1;
+        evaluate(nextArrangement, upcomingAttempts);
+        return upcomingAttempts;
+      });
+    },
+    [arrangement, availableLots, evaluate]
+  );
+
+  if (!activeScenario || !activeMode) {
+    return null;
+  }
+
+  const totalQuantity = arrangement.reduce((sum, lot) => sum + lot.quantity, 0);
+  const totalCost = arrangement.reduce((sum, lot) => sum + lot.quantity * lot.unitCost, 0);
+  const averageCost = totalQuantity === 0 ? 0 : totalCost / totalQuantity;
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle className="text-2xl">{activity.props.title}</CardTitle>
+          <CardDescription>{activity.props.description ?? activity.description}</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Badge variant="secondary" className="flex items-center gap-2">
+            <BarChart3 className="h-4 w-4" />
+            Score: {score}%
+          </Badge>
+          <Badge variant="outline">Attempts: {attempts}</Badge>
+          {completed && <Badge variant="default">Flow complete</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            Scenario
+            <select
+              value={activeScenario.id}
+              onChange={(event) => setScenarioId(event.target.value)}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {scenarios.map((scenario) => (
+                <option key={scenario.id} value={scenario.id}>
+                  {scenario.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            Method
+            <select
+              value={activeMode.id}
+              onChange={(event) => setMethodId(event.target.value)}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {activeScenario.flowModes.map((mode) => (
+                <option key={mode.id} value={mode.id}>
+                  {mode.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button variant="ghost" size="sm" className="gap-2 text-xs" onClick={resetBoard}>
+            <RotateCcw className="h-4 w-4" />
+            Reset arrangement
+          </Button>
+        </div>
+
+        <div className="rounded-xl border bg-muted/10 p-4">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-semibold text-lg">{activeScenario.title}</p>
+              <p className="text-sm text-muted-foreground">{activeScenario.description}</p>
+            </div>
+            <Badge variant="secondary" className="flex items-center gap-2">
+              <Package className="h-4 w-4" />
+              Sales target: {activeScenario.salesQuantity} units
+            </Badge>
+          </div>
+          {activeScenario.context && <p className="mt-2 text-sm text-muted-foreground">{activeScenario.context}</p>}
+          <Separator className="my-3" />
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <span className="font-medium">{activeMode.name}</span>
+            {activeMode.description && <span>{activeMode.description}</span>}
+          </div>
+        </div>
+
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <Warehouse className="h-4 w-4" />
+                <h3 className="text-sm font-semibold uppercase text-muted-foreground">Available lots</h3>
+              </div>
+              <Droppable droppableId={INVENTORY_AVAILABLE_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/70 p-3 min-h-[200px]"
+                  >
+                    {availableLots.map((lot, index) => (
+                      <Draggable key={lot.id} draggableId={lot.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            {...dragProvided.dragHandleProps}
+                            className={cn(
+                              'rounded-lg border bg-card p-3 transition',
+                              snapshot.isDragging && 'ring-2 ring-primary'
+                            )}
+                          >
+                            <p className="font-semibold">{lot.label}</p>
+                            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                              <span>Date: {lot.purchaseDate}</span>
+                              <span>Qty: {lot.quantity}</span>
+                              <span>Unit: ${lot.unitCost.toFixed(2)}</span>
+                            </div>
+                            {lot.notes && <p className="text-xs text-muted-foreground/80">{lot.notes}</p>}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    {availableLots.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">All lots are in the flow</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </section>
+
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <ArrowRight className="h-4 w-4" />
+                <h3 className="text-sm font-semibold uppercase text-muted-foreground">Flow arrangement</h3>
+              </div>
+              <Droppable droppableId={INVENTORY_ARRANGEMENT_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/60 p-3 min-h-[220px]"
+                  >
+                    {arrangement.map((lot, index) => {
+                      const correctId = activeMode.targetOrder[index];
+                      const isCorrectPosition = attempts > 0 && lot.id === correctId;
+                      const isIncorrectPosition = attempts > 0 && lot.id !== correctId;
+                      return (
+                        <Draggable key={lot.id} draggableId={lot.id} index={index}>
+                          {(dragProvided, snapshot) => (
+                            <div
+                              ref={dragProvided.innerRef}
+                              {...dragProvided.draggableProps}
+                              {...dragProvided.dragHandleProps}
+                              className={cn(
+                                'rounded-lg border bg-card p-3 transition',
+                                isCorrectPosition && 'border-green-500 bg-green-50',
+                                isIncorrectPosition && 'border-destructive bg-destructive/10',
+                                snapshot.isDragging && 'ring-2 ring-primary'
+                              )}
+                            >
+                              <div className="flex items-center justify-between">
+                                <p className="font-semibold">
+                                  Step {index + 1}: {lot.label}
+                                </p>
+                                <Badge variant="outline">Qty {lot.quantity}</Badge>
+                              </div>
+                              <p className="text-xs text-muted-foreground">
+                                ${lot.unitCost.toFixed(2)} per unit • Purchased {lot.purchaseDate}
+                              </p>
+                            </div>
+                          )}
+                        </Draggable>
+                      );
+                    })}
+                    {provided.placeholder}
+                    {arrangement.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">Drag lots here to build the cost flow</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+              <div className="mt-4 grid grid-cols-3 gap-3 text-center text-sm text-muted-foreground">
+                <div>
+                  <p className="font-semibold">Lots used</p>
+                  <p>{arrangement.length}</p>
+                </div>
+                <div>
+                  <p className="font-semibold">Units assigned</p>
+                  <p>{totalQuantity}</p>
+                </div>
+                <div>
+                  <p className="font-semibold">Average cost</p>
+                  <p>${averageCost.toFixed(2)}</p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </DragDropContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/drag-drop-exercises/PercentageCalculationSorting.test.tsx
+++ b/components/drag-drop-exercises/PercentageCalculationSorting.test.tsx
@@ -1,0 +1,90 @@
+import { triggerDrag } from '@/lib/test-utils/mock-dnd';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DropResult } from '@hello-pangea/dnd';
+
+import {
+  PercentageCalculationSorting,
+  type PercentageCalculationSortingActivity
+} from './PercentageCalculationSorting';
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId
+} from './useCategorizationExercise';
+import type { PercentageCalculationSortingActivityProps } from '@/lib/db/schema/activities';
+
+const buildActivity = (
+  overrides: Partial<PercentageCalculationSortingActivityProps> = {}
+): PercentageCalculationSortingActivity => ({
+  id: 'activity-percentage',
+  componentKey: 'percentage-calculation-sorting',
+  displayName: 'Percentage Sorting',
+  description: 'Match scenarios to calculation types',
+  props: {
+    title: 'Match the calculation type',
+    description: 'Determine which percentage approach applies to each scenario',
+    calculationTypes: [
+      { id: 'change', title: 'Percentage change', description: 'Compare new vs old', formula: '((New - Old) / Old) × 100' },
+      { id: 'of-total', title: 'Percentage of total', description: 'Part vs whole', formula: '(Part / Whole) × 100' }
+    ],
+    scenarios: [
+      {
+        id: 'scenario-sales',
+        prompt: 'Sales increased from $1000 to $1100',
+        description: 'Find the growth rate',
+        calculationTypeId: 'change',
+        dataPoints: '$1000 → $1100',
+        businessContext: 'Growth comparison',
+        difficulty: 'easy'
+      },
+      {
+        id: 'scenario-labor',
+        prompt: 'Labor costs are $400 of the $1000 budget',
+        description: 'Find percentage of total',
+        calculationTypeId: 'of-total',
+        dataPoints: '$400 / $1000',
+        businessContext: 'Budget review',
+        difficulty: 'medium'
+      }
+    ],
+    showHintsByDefault: false,
+    shuffleItems: false,
+    ...overrides
+  },
+  gradingConfig: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+});
+
+const dropScenario = (itemId: string, zoneId: string) =>
+  act(() => {
+    triggerDrag({
+      draggableId: itemId,
+      type: 'DEFAULT',
+      source: { droppableId: AVAILABLE_ITEMS_DROPPABLE, index: 0 },
+      destination: { droppableId: getZoneDroppableId(zoneId), index: 0 },
+      reason: 'DROP',
+      mode: 'FLUID',
+      combine: null
+    } as DropResult);
+  });
+
+describe('PercentageCalculationSorting', () => {
+  it('submits when all scenarios are matched', async () => {
+    const onSubmit = vi.fn();
+    render(<PercentageCalculationSorting activity={buildActivity()} onSubmit={onSubmit} />);
+
+    dropScenario('scenario-sales', 'change');
+    dropScenario('scenario-labor', 'of-total');
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activityId: 'activity-percentage',
+          score: 100
+        })
+      );
+    });
+  });
+});

--- a/components/drag-drop-exercises/PercentageCalculationSorting.tsx
+++ b/components/drag-drop-exercises/PercentageCalculationSorting.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import { Calculator, Percent, RotateCcw } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { Activity } from '@/lib/db/schema/validators';
+import { type PercentageCalculationSortingActivityProps } from '@/lib/db/schema/activities';
+
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId,
+  useCategorizationExercise,
+  type CategorizationItem
+} from './useCategorizationExercise';
+
+export type PercentageCalculationSortingActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'percentage-calculation-sorting';
+  props: PercentageCalculationSortingActivityProps;
+};
+
+interface PercentageCalculationSortingProps {
+  activity: PercentageCalculationSortingActivity;
+  onSubmit?: (payload: {
+    activityId: string;
+    score: number;
+    attempts: number;
+    responses: Record<string, string[]>;
+    completedAt: Date;
+  }) => void;
+}
+
+type ScenarioItem = PercentageCalculationSortingActivityProps['scenarios'][number] & CategorizationItem;
+
+const difficultyBadge = (difficulty: ScenarioItem['difficulty']) => {
+  switch (difficulty) {
+    case 'easy':
+      return 'secondary';
+    case 'hard':
+      return 'destructive';
+    default:
+      return 'outline';
+  }
+};
+
+export function PercentageCalculationSorting({ activity, onSubmit }: PercentageCalculationSortingProps) {
+  const [showHints, setShowHints] = useState(activity.props.showHintsByDefault);
+
+  const calculationTypes = activity.props.calculationTypes;
+  const zoneIds = useMemo(() => calculationTypes.map((category) => category.id), [calculationTypes]);
+  const scenarios = useMemo<ScenarioItem[]>(
+    () =>
+      activity.props.scenarios.map((scenario) => ({
+        ...scenario,
+        targetId: scenario.calculationTypeId
+      })),
+    [activity.props.scenarios]
+  );
+
+  const handleCompletion = useCallback(
+    ({ score, attempts, placements }: { score: number; attempts: number; placements: Record<string, ScenarioItem[]> }) => {
+      const responses = Object.fromEntries(
+        Object.entries(placements).map(([zoneId, zoneItems]) => [zoneId, zoneItems.map((item) => item.id)])
+      );
+      onSubmit?.({
+        activityId: activity.id,
+        score,
+        attempts,
+        responses,
+        completedAt: new Date()
+      });
+    },
+    [activity.id, onSubmit]
+  );
+
+  const { availableItems, placements, attempts, score, completed, handleDragEnd, reset } = useCategorizationExercise(scenarios, zoneIds, {
+    shuffleItems: activity.props.shuffleItems,
+    resetKey: activity.id,
+    onComplete: handleCompletion
+  });
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle className="text-2xl">{activity.props.title}</CardTitle>
+          <CardDescription>{activity.props.description ?? activity.description}</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Badge variant="secondary" className="flex items-center gap-2">
+            <Percent className="h-4 w-4" />
+            Score: {score}%
+          </Badge>
+          <Badge variant="outline">Attempts: {attempts}</Badge>
+          {completed && <Badge variant="default">Complete</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <label className="inline-flex items-center gap-2">
+            <input type="checkbox" checked={showHints} onChange={() => setShowHints((prev) => !prev)} className="h-4 w-4" />
+            Show formula hints
+          </label>
+          <div className="inline-flex items-center gap-2">
+            <Calculator className="h-4 w-4" />
+            Identify which percentage calculation fits each business scenario.
+          </div>
+        </div>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="grid gap-6 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase text-muted-foreground">Scenarios</h3>
+                <Button variant="ghost" size="sm" onClick={reset} className="gap-2 text-xs">
+                  <RotateCcw className="h-4 w-4" />
+                  Reset
+                </Button>
+              </div>
+              <Droppable droppableId={AVAILABLE_ITEMS_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/70 p-3 min-h-[200px]"
+                  >
+                    {availableItems.map((scenario, index) => (
+                      <Draggable key={scenario.id} draggableId={scenario.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            {...dragProvided.dragHandleProps}
+                            className={cn(
+                              'rounded-lg border bg-card p-3 transition',
+                              snapshot.isDragging && 'ring-2 ring-primary'
+                            )}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="font-semibold">{scenario.prompt}</p>
+                              <Badge variant={difficultyBadge(scenario.difficulty)} className="text-xxs">
+                                {scenario.difficulty.toUpperCase()}
+                              </Badge>
+                            </div>
+                            <p className="text-xs text-muted-foreground">{scenario.dataPoints}</p>
+                            {showHints && scenario.businessContext && (
+                              <p className="mt-2 text-xs text-muted-foreground/80">{scenario.businessContext}</p>
+                            )}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    {availableItems.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">All calculations placed</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </section>
+
+            <section className="space-y-4">
+              {calculationTypes.map((calculation) => (
+                <div key={calculation.id} className="rounded-xl border bg-muted/10 p-4">
+                  <div className="flex flex-col gap-1 pb-3">
+                    <p className="text-lg font-semibold">{calculation.title}</p>
+                    <p className="text-sm text-muted-foreground">{calculation.description}</p>
+                    {showHints && (
+                      <div className="text-xs text-muted-foreground/80">
+                        <p className="font-semibold">Formula: {calculation.formula}</p>
+                        {calculation.applications && <p>Applications: {calculation.applications.join(', ')}</p>}
+                      </div>
+                    )}
+                  </div>
+                  <Droppable droppableId={getZoneDroppableId(calculation.id)}>
+                    {(provided) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/60 p-3 min-h-[120px]"
+                      >
+                        {(placements[calculation.id] ?? []).map((scenario, index) => {
+                          const isCorrect = scenario.targetId === calculation.id;
+                          return (
+                            <Draggable key={scenario.id} draggableId={scenario.id} index={index}>
+                              {(dragProvided, snapshot) => (
+                                <div
+                                  ref={dragProvided.innerRef}
+                                  {...dragProvided.draggableProps}
+                                  {...dragProvided.dragHandleProps}
+                                  className={cn(
+                                    'rounded-lg border bg-card p-3 transition',
+                                    attempts > 0 && (isCorrect ? 'border-green-500 bg-green-50' : 'border-destructive bg-destructive/10'),
+                                    snapshot.isDragging && 'ring-2 ring-primary'
+                                  )}
+                                >
+                                  <p className="font-medium">{scenario.prompt}</p>
+                                  <p className="text-xs text-muted-foreground">{scenario.description}</p>
+                                </div>
+                              )}
+                            </Draggable>
+                          );
+                        })}
+                        {provided.placeholder}
+                        {(placements[calculation.id] ?? []).length === 0 && (
+                          <p className="text-xs text-muted-foreground text-center">Drop scenarios here</p>
+                        )}
+                      </div>
+                    )}
+                  </Droppable>
+                </div>
+              ))}
+            </section>
+          </div>
+        </DragDropContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/drag-drop-exercises/RatioMatching.test.tsx
+++ b/components/drag-drop-exercises/RatioMatching.test.tsx
@@ -1,0 +1,93 @@
+import { triggerDrag } from '@/lib/test-utils/mock-dnd';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DropResult } from '@hello-pangea/dnd';
+
+import { RatioMatching, type RatioMatchingActivity } from './RatioMatching';
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId
+} from './useCategorizationExercise';
+import type { RatioMatchingActivityProps } from '@/lib/db/schema/activities';
+
+const buildActivity = (overrides: Partial<RatioMatchingActivityProps> = {}): RatioMatchingActivity => ({
+  id: 'activity-ratio',
+  componentKey: 'ratio-matching',
+  displayName: 'Ratio Matching',
+  description: 'Match ratios to formulas',
+  props: {
+    title: 'Match ratios',
+    description: 'Connect the formula to the ratio name',
+    ratios: [
+      {
+        id: 'current',
+        name: 'Current ratio',
+        category: 'Liquidity',
+        description: 'Short-term solvency',
+        formulaSummary: 'Current assets ÷ Current liabilities'
+      },
+      {
+        id: 'debt-equity',
+        name: 'Debt-to-equity',
+        category: 'Leverage',
+        description: 'Capital structure',
+        formulaSummary: 'Total debt ÷ Total equity'
+      }
+    ],
+    formulaZones: [
+      {
+        id: 'zone-current',
+        title: 'Current ratio formula',
+        formula: 'Current assets ÷ Current liabilities',
+        category: 'Liquidity',
+        expectedRatioId: 'current'
+      },
+      {
+        id: 'zone-de',
+        title: 'Debt-to-equity formula',
+        formula: 'Total debt ÷ Total equity',
+        category: 'Leverage',
+        expectedRatioId: 'debt-equity'
+      }
+    ],
+    showHintsByDefault: false,
+    shuffleItems: false,
+    ...overrides
+  },
+  gradingConfig: null,
+  createdAt: new Date(),
+  updatedAt: new Date()
+});
+
+const dropRatio = (itemId: string, zoneId: string) =>
+  act(() => {
+    triggerDrag({
+      draggableId: itemId,
+      type: 'DEFAULT',
+      source: { droppableId: AVAILABLE_ITEMS_DROPPABLE, index: 0 },
+      destination: { droppableId: getZoneDroppableId(zoneId), index: 0 },
+      reason: 'DROP',
+      mode: 'FLUID',
+      combine: null
+    } as DropResult);
+  });
+
+describe('RatioMatching', () => {
+  it('submits when ratios match their formulas', async () => {
+    const onSubmit = vi.fn();
+    render(<RatioMatching activity={buildActivity()} onSubmit={onSubmit} />);
+
+    dropRatio('current', 'zone-current');
+    dropRatio('debt-equity', 'zone-de');
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activityId: 'activity-ratio',
+          score: 100
+        })
+      );
+    });
+  });
+});

--- a/components/drag-drop-exercises/RatioMatching.tsx
+++ b/components/drag-drop-exercises/RatioMatching.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import { HelpCircle, RotateCcw, TrendingUp } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { Activity } from '@/lib/db/schema/validators';
+import { type RatioMatchingActivityProps } from '@/lib/db/schema/activities';
+
+import {
+  AVAILABLE_ITEMS_DROPPABLE,
+  getZoneDroppableId,
+  useCategorizationExercise,
+  type CategorizationItem
+} from './useCategorizationExercise';
+
+export type RatioMatchingActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'ratio-matching';
+  props: RatioMatchingActivityProps;
+};
+
+interface RatioMatchingProps {
+  activity: RatioMatchingActivity;
+  onSubmit?: (payload: {
+    activityId: string;
+    score: number;
+    attempts: number;
+    responses: Record<string, string[]>;
+    completedAt: Date;
+  }) => void;
+}
+
+type RatioItem = RatioMatchingActivityProps['ratios'][number] & CategorizationItem;
+
+export function RatioMatching({ activity, onSubmit }: RatioMatchingProps) {
+  const [showHints, setShowHints] = useState(activity.props.showHintsByDefault);
+
+  const formulaZones = activity.props.formulaZones;
+  const zoneIds = useMemo(() => formulaZones.map((zone) => zone.id), [formulaZones]);
+  const ratios = useMemo<RatioItem[]>(
+    () =>
+      activity.props.ratios.map((ratio) => ({
+        ...ratio,
+        targetId: activity.props.formulaZones.find((zone) => zone.expectedRatioId === ratio.id)?.id ?? ''
+      })),
+    [activity.props.formulaZones, activity.props.ratios]
+  );
+
+  const handleCompletion = useCallback(
+    ({ score, attempts, placements }: { score: number; attempts: number; placements: Record<string, RatioItem[]> }) => {
+      const responses = Object.fromEntries(
+        Object.entries(placements).map(([zoneId, zoneItems]) => [zoneId, zoneItems.map((item) => item.id)])
+      );
+      onSubmit?.({
+        activityId: activity.id,
+        score,
+        attempts,
+        responses,
+        completedAt: new Date()
+      });
+    },
+    [activity.id, onSubmit]
+  );
+
+  const { availableItems, placements, attempts, score, completed, handleDragEnd, reset } = useCategorizationExercise(ratios, zoneIds, {
+    shuffleItems: activity.props.shuffleItems,
+    resetKey: activity.id,
+    onComplete: handleCompletion
+  });
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle className="text-2xl">{activity.props.title}</CardTitle>
+          <CardDescription>{activity.props.description ?? activity.description}</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Badge variant="secondary" className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Score: {score}%
+          </Badge>
+          <Badge variant="outline">Attempts: {attempts}</Badge>
+          {completed && <Badge variant="default">Complete</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <label className="inline-flex items-center gap-2">
+            <input type="checkbox" checked={showHints} onChange={() => setShowHints((prev) => !prev)} className="h-4 w-4" />
+            Show ratio guidance
+          </label>
+          <div className="inline-flex items-center gap-2">
+            <HelpCircle className="h-4 w-4" />
+            Match each financial ratio to the formula that calculates it.
+          </div>
+          <Button variant="ghost" size="sm" onClick={reset} className="gap-2 text-xs">
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </Button>
+        </div>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="grid gap-6 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+            <section className="rounded-xl border bg-muted/20 p-4">
+              <h3 className="mb-3 text-sm font-semibold uppercase text-muted-foreground">Ratios</h3>
+              <Droppable droppableId={AVAILABLE_ITEMS_DROPPABLE}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/70 p-3 min-h-[200px]"
+                  >
+                    {availableItems.map((ratio, index) => (
+                      <Draggable key={ratio.id} draggableId={ratio.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            {...dragProvided.dragHandleProps}
+                            className={cn(
+                              'rounded-lg border bg-card p-3 transition',
+                              snapshot.isDragging && 'ring-2 ring-primary'
+                            )}
+                          >
+                            <p className="font-semibold">{ratio.name}</p>
+                            <p className="text-xs text-muted-foreground">{ratio.description}</p>
+                            {showHints && ratio.businessMeaning && (
+                              <p className="mt-1 text-xs text-muted-foreground/80">{ratio.businessMeaning}</p>
+                            )}
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    {availableItems.length === 0 && (
+                      <p className="text-center text-sm text-muted-foreground">All ratios placed</p>
+                    )}
+                  </div>
+                )}
+              </Droppable>
+            </section>
+
+            <section className="space-y-4">
+              {formulaZones.map((zone) => (
+                <div key={zone.id} className="rounded-xl border bg-muted/10 p-4">
+                  <div className="flex items-center gap-2 pb-3">
+                    {zone.emoji && <span>{zone.emoji}</span>}
+                    <div>
+                      <p className="text-lg font-semibold">{zone.title}</p>
+                      <p className="text-sm font-mono text-muted-foreground">{zone.formula}</p>
+                    </div>
+                  </div>
+                  <Droppable droppableId={getZoneDroppableId(zone.id)}>
+                    {(provided) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className="flex flex-col gap-3 rounded-lg border border-dashed bg-background/60 p-3 min-h-[120px]"
+                      >
+                        {(placements[zone.id] ?? []).map((ratio, index) => {
+                          const isCorrect = ratio.targetId === zone.id;
+                          return (
+                            <Draggable key={ratio.id} draggableId={ratio.id} index={index}>
+                              {(dragProvided, snapshot) => (
+                                <div
+                                  ref={dragProvided.innerRef}
+                                  {...dragProvided.draggableProps}
+                                  {...dragProvided.dragHandleProps}
+                                  className={cn(
+                                    'rounded-lg border bg-card p-3 text-sm transition',
+                                    attempts > 0 && (isCorrect ? 'border-green-500 bg-green-50' : 'border-destructive bg-destructive/10'),
+                                    snapshot.isDragging && 'ring-2 ring-primary'
+                                  )}
+                                >
+                                  <p className="font-medium">{ratio.name}</p>
+                                  {showHints && ratio.goodRange && (
+                                    <p className="text-xs text-muted-foreground">Good range: {ratio.goodRange}</p>
+                                  )}
+                                  {showHints && ratio.whyItMatters && (
+                                    <p className="text-xs text-muted-foreground/80">{ratio.whyItMatters}</p>
+                                  )}
+                                </div>
+                              )}
+                            </Draggable>
+                          );
+                        })}
+                        {provided.placeholder}
+                        {(placements[zone.id] ?? []).length === 0 && (
+                          <p className="text-xs text-muted-foreground text-center">Drop the matching ratio here</p>
+                        )}
+                      </div>
+                    )}
+                  </Droppable>
+                </div>
+              ))}
+            </section>
+          </div>
+        </DragDropContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/drag-drop-exercises/useCategorizationExercise.ts
+++ b/components/drag-drop-exercises/useCategorizationExercise.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { DropResult } from '@hello-pangea/dnd';
+
+const AVAILABLE_ITEMS_DROPPABLE = 'available-items';
+
+export interface CategorizationItem {
+  id: string;
+  targetId: string;
+}
+
+export type ZonePlacements<T extends CategorizationItem> = Record<string, T[]>;
+
+interface UseCategorizationExerciseOptions<T extends CategorizationItem> {
+  shuffleItems?: boolean;
+  resetKey?: string;
+  onComplete?: (payload: { score: number; attempts: number; placements: ZonePlacements<T> }) => void;
+}
+
+const shuffle = <T,>(items: T[]) => {
+  const clone = [...items];
+  for (let i = clone.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [clone[i], clone[j]] = [clone[j], clone[i]];
+  }
+  return clone;
+};
+
+const buildPlacements = <T extends CategorizationItem>(zoneIds: string[]): ZonePlacements<T> =>
+  zoneIds.reduce<ZonePlacements<T>>((acc, zoneId) => {
+    acc[zoneId] = [];
+    return acc;
+  }, {});
+
+const zoneFromDroppableId = (droppableId: string): string | null =>
+  droppableId.startsWith('zone-') ? droppableId.replace('zone-', '') : null;
+
+export function getZoneDroppableId(zoneId: string) {
+  return `zone-${zoneId}`;
+}
+
+export function useCategorizationExercise<T extends CategorizationItem>(items: T[], zoneIds: string[], options: UseCategorizationExerciseOptions<T> = {}) {
+  const { shuffleItems = true, resetKey, onComplete } = options;
+
+  const [availableItems, setAvailableItems] = useState<T[]>([]);
+  const [placements, setPlacements] = useState<ZonePlacements<T>>(() => buildPlacements<T>(zoneIds));
+  const [attempts, setAttempts] = useState(0);
+  const [score, setScore] = useState(0);
+  const [completed, setCompleted] = useState(false);
+  const totalItems = items.length;
+
+  useEffect(() => {
+    const initialPlacements = buildPlacements<T>(zoneIds);
+    setPlacements(initialPlacements);
+    setAvailableItems(shuffleItems ? shuffle(items) : [...items]);
+    setAttempts(0);
+    setScore(0);
+    setCompleted(false);
+  }, [items, zoneIds, shuffleItems, resetKey]);
+
+  const evaluate = useCallback(
+    (candidatePlacements: ZonePlacements<T>, upcomingAttempts: number) => {
+      const correct = Object.entries(candidatePlacements).reduce((sum, [zoneId, zoneItems]) => {
+        const zoneCorrect = zoneItems.filter((item) => item.targetId === zoneId).length;
+        return sum + zoneCorrect;
+      }, 0);
+
+      const nextScore = totalItems === 0 ? 0 : Math.round((correct / totalItems) * 100);
+      setScore(nextScore);
+
+      if (!completed && totalItems > 0 && correct === totalItems) {
+        setCompleted(true);
+        onComplete?.({
+          score: nextScore,
+          attempts: upcomingAttempts,
+          placements: candidatePlacements
+        });
+      }
+    },
+    [completed, onComplete, totalItems]
+  );
+
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      const { source, destination } = result;
+      if (!destination) return;
+      if (destination.droppableId === source.droppableId && destination.index === source.index) {
+        return;
+      }
+
+      const updatedAvailable = [...availableItems];
+      const updatedPlacements = Object.keys(placements).reduce<ZonePlacements<T>>((acc, key) => {
+        acc[key] = [...placements[key]];
+        return acc;
+      }, {});
+
+      const sourceZone = zoneFromDroppableId(source.droppableId);
+      const destinationZone = zoneFromDroppableId(destination.droppableId);
+
+      let movingItem: T | undefined;
+      if (sourceZone) {
+        movingItem = updatedPlacements[sourceZone].splice(source.index, 1)[0];
+      } else if (source.droppableId === AVAILABLE_ITEMS_DROPPABLE) {
+        movingItem = updatedAvailable.splice(source.index, 1)[0];
+      }
+
+      if (!movingItem) return;
+
+      if (destinationZone) {
+        updatedPlacements[destinationZone].splice(destination.index, 0, movingItem);
+      } else if (destination.droppableId === AVAILABLE_ITEMS_DROPPABLE) {
+        updatedAvailable.splice(destination.index, 0, movingItem);
+      } else {
+        return;
+      }
+
+      setAvailableItems(updatedAvailable);
+      setPlacements(updatedPlacements);
+      setAttempts((prev) => {
+        const upcomingAttempts = prev + 1;
+        evaluate(updatedPlacements, upcomingAttempts);
+        return upcomingAttempts;
+      });
+    },
+    [availableItems, placements, evaluate]
+  );
+
+  const reset = useCallback(() => {
+    const initialPlacements = buildPlacements<T>(zoneIds);
+    setPlacements(initialPlacements);
+    setAvailableItems(shuffleItems ? shuffle(items) : [...items]);
+    setAttempts(0);
+    setScore(0);
+    setCompleted(false);
+  }, [items, shuffleItems, zoneIds]);
+
+  return {
+    AVAILABLE_ITEMS_DROPPABLE,
+    availableItems,
+    placements,
+    attempts,
+    score,
+    completed,
+    handleDragEnd,
+    reset,
+    getZoneDroppableId
+  };
+}
+
+export { AVAILABLE_ITEMS_DROPPABLE };

--- a/components/exercises/DragAndDrop.test.tsx
+++ b/components/exercises/DragAndDrop.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { triggerDrag } from '@/lib/test-utils/mock-dnd'
 import { render, screen } from '@testing-library/react'
 import { act } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -6,54 +6,6 @@ import type { DropResult } from '@hello-pangea/dnd'
 
 import { DragAndDrop, type DragAndDropActivity } from './DragAndDrop'
 import type { DragAndDropActivityProps } from '@/lib/db/schema/activities'
-
-const dragHandlers: { onDragEnd: ((result: DropResult) => void) | null } = { onDragEnd: null }
-
-interface MockDroppableProvided {
-  droppableProps: Record<string, unknown>
-  innerRef: () => void
-  placeholder: ReactNode
-}
-
-interface MockDraggableProvided {
-  draggableProps: Record<string, unknown>
-  dragHandleProps: Record<string, unknown>
-  innerRef: () => void
-}
-
-interface MockDraggableSnapshot {
-  isDragging: boolean
-}
-
-vi.mock('@hello-pangea/dnd', () => {
-  return {
-    DragDropContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (result: DropResult) => void }) => {
-      dragHandlers.onDragEnd = onDragEnd
-      return <div data-testid="drag-drop-context">{children}</div>
-    },
-    Droppable: ({ children, droppableId }: { children: (provided: MockDroppableProvided) => ReactNode; droppableId: string }) => (
-      <div data-testid={`droppable-${droppableId}`}>
-        {children({
-          droppableProps: { 'data-droppable-id': droppableId },
-          innerRef: vi.fn(),
-          placeholder: null
-        })}
-      </div>
-    ),
-    Draggable: ({ children, draggableId }: { children: (provided: MockDraggableProvided, snapshot: MockDraggableSnapshot) => ReactNode; draggableId: string }) => (
-      <div data-testid={`draggable-${draggableId}`}>
-        {children(
-          {
-            draggableProps: {},
-            dragHandleProps: {},
-            innerRef: vi.fn()
-          },
-          { isDragging: false }
-        )}
-      </div>
-    )
-  }
-})
 
 const buildActivity = (overrides: Partial<DragAndDropActivityProps> = {}): DragAndDropActivity => ({
   id: 'activity-dnd',
@@ -85,9 +37,9 @@ describe('DragAndDrop', () => {
     const onSubmit = vi.fn()
     render(<DragAndDrop activity={buildActivity()} onSubmit={onSubmit} />)
 
-    const submitMove = (itemId: string, zoneId: string) => {
+    const submitMove = (itemId: string, zoneId: string) =>
       act(() => {
-        dragHandlers.onDragEnd?.({
+        triggerDrag({
           draggableId: itemId,
           type: 'DEFAULT',
           source: { droppableId: 'available-items', index: 0 },
@@ -97,7 +49,6 @@ describe('DragAndDrop', () => {
           combine: null
         } as DropResult)
       })
-    }
 
     submitMove('term-assets', 'def-assets')
     submitMove('term-liabilities', 'def-liabilities')

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -111,3 +111,14 @@ Focused summary of learnings from Epic #2 (issues #3–#12).
 - Drag/drop UI needs accessible fallbacks—adding select inputs for journal rows keeps tests deterministic and students on keyboards unblocked.
 - When stubbing complex libs like `@hello-pangea/dnd`, define typed mock helpers so ESLint/TS don’t regress while we drive interactions via Vitest.
 - `activityPropsSchemas` now drive a lot of surface area, so mock factories must default every required field; otherwise Next build fails before PR review.
+
+## PR #47 (Issue #29) - feat/29-task-6-interactive-exercises--part-2a-5-drag-drop-exercises
+
+### Highlights
+- Introduced the curriculum-specific drag/drop exercises (`AccountCategorization`, `BudgetCategorySort`, `PercentageCalculationSorting`, `InventoryFlowDiagram`, `RatioMatching`) under `components/drag-drop-exercises/` so Unit 4–7 lessons can load database-driven props instead of hardcoded JSX.
+- Expanded `activityPropsSchemas`/`validators` with five new Supabase activity types plus a shared categorization hook, keeping exercise props strongly typed across Drizzle + runtime Zod validation.
+- Added a reusable Vitest mock for `@hello-pangea/dnd` and authored focused suites for each exercise, alongside lint/test/build runs, to prove drag-drop behavior and submission wiring end-to-end.
+
+### Lessons
+- DnD mocks must be registered before component imports; pulling in the mock helper at the top of each test file prevents real library hydration and keeps handlers controllable.
+- Categorization utilities should expose droppable IDs so both components and tests stay in sync—removing string literals avoided brittle assertions while porting multiple exercises.

--- a/lib/db/schema/activities.ts
+++ b/lib/db/schema/activities.ts
@@ -10,6 +10,111 @@ const matchingItemSchema = z.object({
   description: z.string().optional()
 });
 
+const accountCategorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  emoji: z.string().optional(),
+  whyItMatters: z.string().optional()
+});
+
+const accountItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  categoryId: z.string(),
+  realWorldExample: z.string().optional(),
+  hint: z.string().optional()
+});
+
+const impactLevelSchema = z.enum(['low', 'medium', 'high']);
+
+const budgetCategorySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  emoji: z.string().optional(),
+  color: z.string().optional(),
+  profitImpact: z.string().optional(),
+  strategyNote: z.string().optional()
+});
+
+const budgetExpenseSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string(),
+  categoryId: z.string(),
+  cafeContext: z.string().optional(),
+  amount: z.number().nonnegative(),
+  impact: impactLevelSchema.default('medium')
+});
+
+const percentageCategorySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  emoji: z.string().optional(),
+  formula: z.string(),
+  applications: z.array(z.string()).optional()
+});
+
+const percentageScenarioSchema = z.object({
+  id: z.string(),
+  prompt: z.string(),
+  description: z.string(),
+  calculationTypeId: z.string(),
+  dataPoints: z.string(),
+  businessContext: z.string().optional(),
+  difficulty: z.enum(['easy', 'medium', 'hard']).default('medium'),
+  formula: z.string().optional()
+});
+
+const inventoryLotSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  purchaseDate: z.string(),
+  quantity: z.number().int().positive(),
+  unitCost: z.number().nonnegative(),
+  notes: z.string().optional()
+});
+
+const inventoryFlowModeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  targetOrder: z.array(z.string()).min(1)
+});
+
+const inventoryScenarioSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  context: z.string().optional(),
+  salesQuantity: z.number().int().positive(),
+  lots: z.array(inventoryLotSchema).min(1),
+  flowModes: z.array(inventoryFlowModeSchema).min(1)
+});
+
+const ratioDefinitionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  category: z.string(),
+  description: z.string(),
+  businessMeaning: z.string().optional(),
+  goodRange: z.string().optional(),
+  whyItMatters: z.string().optional(),
+  formulaSummary: z.string()
+});
+
+const ratioFormulaZoneSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  formula: z.string(),
+  category: z.string(),
+  emoji: z.string().optional(),
+  expectedRatioId: z.string()
+});
+
 const blankSentenceSchema = z.object({
   id: z.string(),
   text: z.string(),
@@ -76,6 +181,43 @@ export const activityPropsSchemas = {
     showHints: z.boolean().default(false),
     shuffleItems: z.boolean().default(true)
   }),
+  'account-categorization': z.object({
+    title: z.string(),
+    description: z.string(),
+    categories: z.array(accountCategorySchema).min(1),
+    accounts: z.array(accountItemSchema).min(1),
+    showHintsByDefault: z.boolean().default(false),
+    shuffleItems: z.boolean().default(true)
+  }),
+  'budget-category-sort': z.object({
+    title: z.string(),
+    description: z.string(),
+    categories: z.array(budgetCategorySchema).min(1),
+    expenses: z.array(budgetExpenseSchema).min(1),
+    showHintsByDefault: z.boolean().default(false),
+    shuffleItems: z.boolean().default(true)
+  }),
+  'percentage-calculation-sorting': z.object({
+    title: z.string(),
+    description: z.string(),
+    calculationTypes: z.array(percentageCategorySchema).min(1),
+    scenarios: z.array(percentageScenarioSchema).min(1),
+    showHintsByDefault: z.boolean().default(false),
+    shuffleItems: z.boolean().default(true)
+  }),
+  'inventory-flow-diagram': z.object({
+    title: z.string(),
+    description: z.string(),
+    scenarios: z.array(inventoryScenarioSchema).min(1)
+  }),
+  'ratio-matching': z.object({
+    title: z.string(),
+    description: z.string(),
+    ratios: z.array(ratioDefinitionSchema).min(1),
+    formulaZones: z.array(ratioFormulaZoneSchema).min(1),
+    showHintsByDefault: z.boolean().default(false),
+    shuffleItems: z.boolean().default(true)
+  }),
   'fill-in-the-blank': z.object({
     title: z.string(),
     description: z.string(),
@@ -124,6 +266,11 @@ export type ActivityProps = {
 
 export type ComprehensionQuizActivityProps = z.infer<typeof activityPropsSchemas['comprehension-quiz']>;
 export type DragAndDropActivityProps = z.infer<typeof activityPropsSchemas['drag-and-drop']>;
+export type AccountCategorizationActivityProps = z.infer<typeof activityPropsSchemas['account-categorization']>;
+export type BudgetCategorySortActivityProps = z.infer<typeof activityPropsSchemas['budget-category-sort']>;
+export type PercentageCalculationSortingActivityProps = z.infer<typeof activityPropsSchemas['percentage-calculation-sorting']>;
+export type InventoryFlowDiagramActivityProps = z.infer<typeof activityPropsSchemas['inventory-flow-diagram']>;
+export type RatioMatchingActivityProps = z.infer<typeof activityPropsSchemas['ratio-matching']>;
 export type FillInTheBlankActivityProps = z.infer<typeof activityPropsSchemas['fill-in-the-blank']>;
 export type JournalEntryActivityProps = z.infer<typeof activityPropsSchemas['journal-entry-building']>;
 export type ReflectionJournalActivityProps = z.infer<typeof activityPropsSchemas['reflection-journal']>;

--- a/lib/db/schema/validators.ts
+++ b/lib/db/schema/validators.ts
@@ -18,6 +18,11 @@ import { studentProgress } from './student-progress';
 const activityPropsSchema = z.union([
   activityPropsSchemas['comprehension-quiz'],
   activityPropsSchemas['drag-and-drop'],
+  activityPropsSchemas['account-categorization'],
+  activityPropsSchemas['budget-category-sort'],
+  activityPropsSchemas['percentage-calculation-sorting'],
+  activityPropsSchemas['inventory-flow-diagram'],
+  activityPropsSchemas['ratio-matching'],
   activityPropsSchemas['fill-in-the-blank'],
   activityPropsSchemas['journal-entry-building'],
   activityPropsSchemas['reflection-journal'],

--- a/lib/test-utils/mock-dnd.tsx
+++ b/lib/test-utils/mock-dnd.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import type { DropResult } from '@hello-pangea/dnd';
+import { vi } from 'vitest';
+
+export const dragHandlers: { onDragEnd: ((result: DropResult) => void) | null } = {
+  onDragEnd: null
+};
+
+interface MockDroppableProvided {
+  droppableProps: Record<string, unknown>;
+  innerRef: () => void;
+  placeholder: ReactNode;
+}
+
+interface MockDraggableProvided {
+  draggableProps: Record<string, unknown>;
+  dragHandleProps: Record<string, unknown>;
+  innerRef: () => void;
+}
+
+interface MockDraggableSnapshot {
+  isDragging: boolean;
+}
+
+vi.mock('@hello-pangea/dnd', () => {
+  return {
+    DragDropContext: ({
+      children,
+      onDragEnd
+    }: {
+      children: ReactNode;
+      onDragEnd: (result: DropResult) => void;
+    }) => {
+      dragHandlers.onDragEnd = onDragEnd;
+      return <div data-testid="drag-drop-context">{children}</div>;
+    },
+    Droppable: ({
+      children,
+      droppableId
+    }: {
+      children: (provided: MockDroppableProvided) => ReactNode;
+      droppableId: string;
+    }) => (
+      <div data-testid={`droppable-${droppableId}`}>
+        {children({
+          droppableProps: { 'data-droppable-id': droppableId },
+          innerRef: vi.fn(),
+          placeholder: null
+        })}
+      </div>
+    ),
+    Draggable: ({
+      children,
+      draggableId
+    }: {
+      children: (provided: MockDraggableProvided, snapshot: MockDraggableSnapshot) => ReactNode;
+      draggableId: string;
+    }) => (
+      <div data-testid={`draggable-${draggableId}`}>
+        {children(
+          {
+            draggableProps: {},
+            dragHandleProps: {},
+            innerRef: vi.fn()
+          },
+          { isDragging: false }
+        )}
+      </div>
+    )
+  };
+});
+
+export function triggerDrag(result: DropResult) {
+  dragHandlers.onDragEnd?.(result);
+}


### PR DESCRIPTION
## Summary
- port the five drag/drop exercises to Supabase-backed components with reusable categorization utilities
- extend activity schemas/validators plus add the shared DnD mock helper so data + tests stay typed
- cover each exercise with Vitest suites while wiring the inventory flow ordering logic and documenting the work

## Testing
- npm run lint
- npm run test
- npm run build

Closes #29