### PR TITLE
feat: migrate chart visualizations (#33)

### DIFF
--- a/components/charts/BarChart.test.tsx
+++ b/components/charts/BarChart.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+
+import { BarChart } from './BarChart';
+
+const barData = [
+  { unit: 'Unit 1', completed: 20, assigned: 25 },
+  { unit: 'Unit 2', completed: 18, assigned: 24 }
+];
+
+const barSeries = [
+  { key: 'completed', label: 'Completed' },
+  { key: 'assigned', label: 'Assigned' }
+];
+
+describe('BarChart', () => {
+  it('shows stacked bar legend entries and aria label', () => {
+    render(
+      <BarChart
+        title="Lesson Progress"
+        data={barData}
+        series={barSeries}
+        xAxisKey="unit"
+        stacked
+        ariaLabel="Lesson progress chart"
+      />
+    );
+
+    expect(screen.getByRole('img', { name: /lesson progress chart/i })).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Assigned')).toBeInTheDocument();
+  });
+});

--- a/components/charts/BarChart.tsx
+++ b/components/charts/BarChart.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  type XAxisProps,
+  type YAxisProps
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import { buildChartConfig, type ChartDataPoint, type ChartSeries } from "./chart-types";
+
+export interface BarChartProps {
+  title?: string;
+  description?: string;
+  data: ChartDataPoint[];
+  series: ChartSeries[];
+  xAxisKey?: string;
+  showCard?: boolean;
+  showLegend?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  height?: number;
+  className?: string;
+  ariaLabel?: string;
+  stacked?: boolean;
+  layout?: "horizontal" | "vertical";
+  formatValue?: (value: number) => string;
+  xAxisProps?: Partial<XAxisProps>;
+  yAxisProps?: Partial<YAxisProps>;
+}
+
+const DEFAULT_BAR_FORMAT = (value: number) => value.toLocaleString();
+
+export function BarChart({
+  title,
+  description,
+  data,
+  series,
+  xAxisKey = "label",
+  showCard = true,
+  showLegend = true,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = true,
+  height = 340,
+  className,
+  ariaLabel,
+  stacked = false,
+  layout = "horizontal",
+  formatValue = DEFAULT_BAR_FORMAT,
+  xAxisProps,
+  yAxisProps
+}: BarChartProps) {
+  const chartConfig = useMemo(() => buildChartConfig(series), [series]);
+  const containerLabel = ariaLabel ?? `${title ?? "Bar"} chart visualization`;
+
+  const chart = (
+    <figure className={cn("space-y-3", showCard ? "" : className)}>
+      {!showCard && (title || description) && (
+        <div className="space-y-1">
+          {title && <p className="text-base font-semibold text-foreground">{title}</p>}
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+      )}
+      <ChartContainer
+        role="img"
+        aria-label={containerLabel}
+        config={chartConfig}
+        className="w-full rounded-xl border border-gray-100 bg-white"
+        style={{ height }}
+        data-testid="bar-chart"
+      >
+        <RechartsBarChart
+          data={data}
+          layout={layout === "vertical" ? "vertical" : "horizontal"}
+          margin={{ top: 16, right: 16, left: 16, bottom: 16 }}
+        >
+          {showGrid && <CartesianGrid strokeDasharray="3 3" />}
+          {showXAxis && (
+            <XAxis
+              dataKey={layout === "vertical" ? undefined : xAxisKey}
+              type={layout === "vertical" ? "number" : "category"}
+              tickLine={false}
+              axisLine={false}
+              className="text-xs"
+              {...xAxisProps}
+            />
+          )}
+          {showYAxis && (
+            <YAxis
+              dataKey={layout === "vertical" ? xAxisKey : undefined}
+              type={layout === "vertical" ? "category" : "number"}
+              tickLine={false}
+              axisLine={false}
+              className="text-xs"
+              tickFormatter={(value) =>
+                layout === "vertical" ? String(value) : formatValue(Number(value))
+              }
+              {...yAxisProps}
+            />
+          )}
+          <ChartTooltip
+            cursor={{ fill: "rgba(0,0,0,0.04)" }}
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => [
+                  formatValue(Number(value)),
+                  series.find((item) => item.key === name)?.label ?? name
+                ]}
+              />
+            }
+          />
+          {series.map((item) => (
+            <Bar
+              key={item.key}
+              dataKey={item.key}
+              fill={`var(--color-${item.key})`}
+              radius={4}
+              stackId={stacked ? "stack" : undefined}
+              aria-label={`${item.label} bar series`}
+            />
+          ))}
+          {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        </RechartsBarChart>
+      </ChartContainer>
+    </figure>
+  );
+
+  if (!showCard) {
+    return chart;
+  }
+
+  return (
+    <Card className={cn("w-full", className)}>
+      {(title || description) && (
+        <CardHeader className="space-y-1">
+          {title && <CardTitle className="text-base">{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/charts/BreakEvenChart.test.tsx
+++ b/components/charts/BreakEvenChart.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BreakEvenChart } from './BreakEvenChart';
+
+describe('BreakEvenChart', () => {
+  it('recalculates break-even units when inputs change', async () => {
+    const user = userEvent.setup();
+    render(<BreakEvenChart fixedCosts={5000} sellingPrice={50} variableCostRate={0.4} />);
+
+    const unitsBefore = screen.getByTestId('breakeven-units').textContent;
+    const sellingPriceInput = screen.getByLabelText(/selling price/i);
+
+    await user.clear(sellingPriceInput);
+    await user.type(sellingPriceInput, '100');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('breakeven-units').textContent).not.toEqual(unitsBefore);
+    });
+  });
+});

--- a/components/charts/BreakEvenChart.tsx
+++ b/components/charts/BreakEvenChart.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CartesianGrid, Line, LineChart as RechartsLineChart, ReferenceLine, XAxis, YAxis } from "recharts";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import { buildChartConfig, formatCurrency } from "./chart-types";
+
+export interface BreakEvenChartProps {
+  fixedCosts?: number;
+  variableCostRate?: number;
+  sellingPrice?: number;
+  interactive?: boolean;
+  showCard?: boolean;
+  className?: string;
+  height?: number;
+  currency?: string;
+}
+
+interface BreakEvenDataPoint {
+  units: number;
+  revenue: number;
+  totalCosts: number;
+  profit: number;
+}
+
+export function BreakEvenChart({
+  fixedCosts: defaultFixedCosts = 10000,
+  variableCostRate: defaultVariableRate = 0.6,
+  sellingPrice: defaultSellingPrice = 25,
+  interactive = true,
+  showCard = true,
+  className,
+  height = 360,
+  currency = "USD"
+}: BreakEvenChartProps) {
+  const [fixedCosts, setFixedCosts] = useState(defaultFixedCosts);
+  const [variableCostRate, setVariableCostRate] = useState(defaultVariableRate);
+  const [sellingPrice, setSellingPrice] = useState(defaultSellingPrice);
+
+  const summary = useMemo(() => {
+    const contributionMargin = sellingPrice - sellingPrice * variableCostRate;
+    const breakEvenUnits = contributionMargin > 0 ? Math.ceil(fixedCosts / contributionMargin) : 0;
+    const breakEvenRevenue = breakEvenUnits * sellingPrice;
+
+    return {
+      contributionMargin,
+      contributionMarginRatio: sellingPrice ? contributionMargin / sellingPrice : 0,
+      breakEvenUnits,
+      breakEvenRevenue
+    };
+  }, [fixedCosts, variableCostRate, sellingPrice]);
+
+  const chartData = useMemo<BreakEvenDataPoint[]>(() => {
+    const maxUnits = Math.max(summary.breakEvenUnits * 2, 100);
+    const step = Math.max(Math.floor(maxUnits / 18), 5);
+    const points: BreakEvenDataPoint[] = [];
+
+    for (let units = 0; units <= maxUnits; units += step) {
+      const revenue = units * sellingPrice;
+      const totalCosts = fixedCosts + units * sellingPrice * variableCostRate;
+      points.push({
+        units,
+        revenue,
+        totalCosts,
+        profit: revenue - totalCosts
+      });
+    }
+
+    return points;
+  }, [fixedCosts, variableCostRate, sellingPrice, summary.breakEvenUnits]);
+
+  const chartConfig = useMemo(
+    () =>
+      buildChartConfig([
+        { key: "revenue", label: "Revenue", color: "hsl(142, 70%, 45%)" },
+        { key: "totalCosts", label: "Total Costs", color: "hsl(6, 78%, 57%)" },
+        { key: "profit", label: "Profit / Loss", color: "hsl(210, 84%, 53%)" }
+      ]),
+    []
+  );
+
+  const resetValues = () => {
+    setFixedCosts(defaultFixedCosts);
+    setVariableCostRate(defaultVariableRate);
+    setSellingPrice(defaultSellingPrice);
+  };
+
+  const chart = (
+    <div className="space-y-4" data-testid="breakeven-chart">
+      {interactive && (
+        <div className="grid gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4 md:grid-cols-4">
+          <div className="space-y-1">
+            <Label htmlFor="fixed-costs">Fixed Costs</Label>
+            <Input
+              id="fixed-costs"
+              type="number"
+              min={0}
+              value={fixedCosts}
+              onChange={(event) => setFixedCosts(Number(event.target.value) || 0)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="variable-rate">Variable Cost Rate</Label>
+            <Input
+              id="variable-rate"
+              type="number"
+              min={0}
+              max={1}
+              step={0.01}
+              value={variableCostRate}
+              onChange={(event) => setVariableCostRate(Number(event.target.value) || 0)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="selling-price">Selling Price</Label>
+            <Input
+              id="selling-price"
+              type="number"
+              min={0}
+              value={sellingPrice}
+              onChange={(event) => setSellingPrice(Number(event.target.value) || 0)}
+            />
+          </div>
+          <div className="flex items-end">
+            <Button type="button" variant="outline" className="w-full" onClick={resetValues}>
+              Reset
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <ChartContainer
+        role="img"
+        aria-label="Break-even analysis chart with revenue, cost, and profit"
+        config={chartConfig}
+        className="w-full rounded-xl border border-gray-100 bg-white"
+        style={{ height }}
+      >
+        <RechartsLineChart
+          data={chartData}
+          margin={{
+            top: 16,
+            right: 24,
+            left: 24,
+            bottom: 16
+          }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="units" tickLine={false} axisLine={false} />
+          <YAxis tickFormatter={(value) => formatCurrency(Number(value), currency)} />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => [
+                  formatCurrency(Number(value), currency),
+                  chartConfig[name as keyof typeof chartConfig]?.label ?? name
+                ]}
+              />
+            }
+          />
+          <Line
+            type="monotone"
+            dataKey="revenue"
+            stroke="var(--color-revenue)"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="totalCosts"
+            stroke="var(--color-totalCosts)"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="profit"
+            stroke="var(--color-profit)"
+            strokeWidth={2}
+            dot={false}
+          />
+          <ReferenceLine
+            x={summary.breakEvenUnits}
+            stroke="var(--color-revenue)"
+            strokeDasharray="5 5"
+            label={{ value: "Break-even", position: "top", fill: "hsl(222, 47%, 11%)" }}
+          />
+          <ChartLegend content={<ChartLegendContent />} />
+        </RechartsLineChart>
+      </ChartContainer>
+
+      <dl className="grid gap-4 rounded-lg border border-gray-200 p-4 text-sm md:grid-cols-4">
+        <div>
+          <dt className="text-muted-foreground">Break-even Units</dt>
+          <dd className="text-lg font-semibold" data-testid="breakeven-units">
+            {summary.breakEvenUnits.toLocaleString()}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Break-even Revenue</dt>
+          <dd className="text-lg font-semibold">
+            {formatCurrency(summary.breakEvenRevenue, currency)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Contribution Margin</dt>
+          <dd className="text-lg font-semibold">
+            {formatCurrency(summary.contributionMargin, currency)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Contribution Margin Ratio</dt>
+          <dd className="text-lg font-semibold">
+            {(summary.contributionMarginRatio * 100).toFixed(1)}%
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+
+  if (!showCard) {
+    return chart;
+  }
+
+  return (
+    <Card className={cn("w-full", className)}>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base">Break-even Analysis</CardTitle>
+        <CardDescription>Explore how cost structure impacts profitability.</CardDescription>
+      </CardHeader>
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/charts/DoughnutChart.test.tsx
+++ b/components/charts/DoughnutChart.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import { DoughnutChart } from './DoughnutChart';
+
+const doughnutSegments = [
+  { id: 'cash', label: 'Cash', value: 3200 },
+  { id: 'receivables', label: 'Receivables', value: 1800 }
+];
+
+describe('DoughnutChart', () => {
+  it('shows formatted total in the center overlay', () => {
+    render(<DoughnutChart title="Working Capital" segments={doughnutSegments} totalLabel="Working Capital" />);
+
+    expect(screen.getByRole('img', { name: /working capital/i })).toBeInTheDocument();
+    expect(screen.getAllByText('Working Capital').length).toBeGreaterThan(0);
+    expect(screen.getByText('$5,000')).toBeInTheDocument();
+  });
+});

--- a/components/charts/DoughnutChart.tsx
+++ b/components/charts/DoughnutChart.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo } from "react";
+import { Cell, Pie, PieChart as RechartsPieChart } from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import {
+  buildChartConfig,
+  type ChartSegment,
+  DEFAULT_CHART_COLORS,
+  formatCurrency
+} from "./chart-types";
+
+export interface DoughnutChartProps {
+  title?: string;
+  description?: string;
+  segments: ChartSegment[];
+  showCard?: boolean;
+  showLegend?: boolean;
+  className?: string;
+  ariaLabel?: string;
+  height?: number;
+  innerRadius?: number;
+  valueFormatter?: (value: number) => string;
+  totalLabel?: string;
+}
+
+export function DoughnutChart({
+  title,
+  description,
+  segments,
+  showCard = true,
+  showLegend = true,
+  className,
+  ariaLabel,
+  height = 340,
+  innerRadius = 70,
+  valueFormatter = (value) => formatCurrency(value),
+  totalLabel = "Total"
+}: DoughnutChartProps) {
+  const chartConfig = useMemo(
+    () =>
+      buildChartConfig(
+        segments.map((segment, index) => ({
+          key: segment.id,
+          label: segment.label,
+          color: segment.color ?? DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length]
+        }))
+      ),
+    [segments]
+  );
+
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+  const data = segments.map((segment, index) => ({
+    name: segment.label,
+    value: segment.value,
+    key: segment.id,
+    fill: segment.color ?? DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length]
+  }));
+
+  const containerLabel =
+    ariaLabel ?? `${title ?? "Doughnut"} chart showing ${segments.length} categories`;
+
+  const chart = (
+    <figure className={cn("space-y-3", showCard ? "" : className)}>
+      {!showCard && (title || description) && (
+        <div className="space-y-1">
+          {title && <p className="text-base font-semibold text-foreground">{title}</p>}
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+      )}
+      <div className="relative">
+        <ChartContainer
+          role="img"
+          aria-label={containerLabel}
+          config={chartConfig}
+          className="w-full rounded-xl border border-gray-100 bg-white"
+          style={{ height }}
+          data-testid="doughnut-chart"
+        >
+          <RechartsPieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              outerRadius="80%"
+              innerRadius={innerRadius}
+              paddingAngle={2}
+            >
+              {data.map((entry) => (
+                <Cell key={entry.key} fill={entry.fill} stroke="rgba(255,255,255,0.8)" />
+              ))}
+            </Pie>
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value, name) => [valueFormatter(Number(value)), name]}
+                  labelFormatter={() => ""}
+                  indicator="dot"
+                />
+              }
+            />
+            {showLegend && (
+              <ChartLegend
+                content={<ChartLegendContent />}
+                verticalAlign="bottom"
+                height={36}
+              />
+            )}
+          </RechartsPieChart>
+        </ChartContainer>
+        <div
+          className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center"
+          aria-hidden="true"
+        >
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">{totalLabel}</span>
+          <span className="text-lg font-semibold text-foreground">{valueFormatter(total)}</span>
+        </div>
+      </div>
+    </figure>
+  );
+
+  if (!showCard) {
+    return chart;
+  }
+
+  return (
+    <Card className={cn("w-full", className)}>
+      {(title || description) && (
+        <CardHeader className="space-y-1">
+          {title && <CardTitle className="text-base">{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/charts/FinancialDashboard.test.tsx
+++ b/components/charts/FinancialDashboard.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { FinancialDashboard } from './FinancialDashboard';
+
+describe('FinancialDashboard', () => {
+  it('calls refresh and export handlers', async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const onExport = vi.fn();
+
+    render(<FinancialDashboard onRefresh={onRefresh} onExport={onExport} />);
+
+    await user.click(screen.getByRole('button', { name: /refresh data/i }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(onExport).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows KPI values from props', () => {
+    render(
+      <FinancialDashboard
+        kpis={[
+          { title: 'Custom Revenue', value: '$10,000', change: 5, trend: 'up' },
+          { title: 'Custom Profit', value: '$6,000', change: -2, trend: 'down' }
+        ]}
+        refreshable={false}
+        exportable={false}
+      />
+    );
+
+    expect(screen.getByText('Custom Revenue')).toBeInTheDocument();
+    expect(screen.getByText('$10,000')).toBeInTheDocument();
+    expect(screen.getByText('Custom Profit')).toBeInTheDocument();
+  });
+});

--- a/components/charts/FinancialDashboard.tsx
+++ b/components/charts/FinancialDashboard.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Download, RefreshCw, TrendingDown, TrendingUp } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+import { BarChart } from "./BarChart";
+import { DoughnutChart } from "./DoughnutChart";
+import { LineChart } from "./LineChart";
+import { PieChart } from "./PieChart";
+import type { ChartDataPoint, ChartSegment, ChartSeries } from "./chart-types";
+
+interface FinancialKpi {
+  title: string;
+  value: string;
+  change: number;
+  trend: "up" | "down";
+  helperText?: string;
+}
+
+export interface FinancialDashboardProps {
+  title?: string;
+  description?: string;
+  className?: string;
+  monthlyMetrics?: ChartDataPoint[];
+  performanceSeries?: ChartSeries[];
+  cashflowSeries?: ChartSeries[];
+  accountBreakdown?: ChartSegment[];
+  kpis?: FinancialKpi[];
+  refreshable?: boolean;
+  exportable?: boolean;
+  onRefresh?: () => Promise<void> | void;
+  onExport?: () => void;
+}
+
+const DEFAULT_MONTHLY_DATA: ChartDataPoint[] = [
+  { month: "Jan", revenue: 15000, expenses: 12000, profit: 3000, cashFlow: 3200 },
+  { month: "Feb", revenue: 17500, expenses: 13250, profit: 4250, cashFlow: 3600 },
+  { month: "Mar", revenue: 18200, expenses: 14000, profit: 4200, cashFlow: 3900 },
+  { month: "Apr", revenue: 21000, expenses: 16200, profit: 4800, cashFlow: 4200 },
+  { month: "May", revenue: 22500, expenses: 17100, profit: 5400, cashFlow: 4500 },
+  { month: "Jun", revenue: 24000, expenses: 18000, profit: 6000, cashFlow: 5100 }
+];
+
+const DEFAULT_ACCOUNTS: ChartSegment[] = [
+  { id: "cash", label: "Cash", value: 8600 },
+  { id: "receivables", label: "Receivables", value: 3800 },
+  { id: "inventory", label: "Inventory", value: 5400 },
+  { id: "equipment", label: "Equipment", value: 15000 },
+  { id: "payables", label: "Payables", value: 3200 }
+];
+
+const DEFAULT_KPIS: FinancialKpi[] = [
+  { title: "Total Revenue", value: "$118,200", change: 12.4, trend: "up", helperText: "vs last 6 months" },
+  { title: "Net Profit", value: "$27,650", change: 8.1, trend: "up", helperText: "margin 23.4%" },
+  { title: "Operating Cash", value: "$24,000", change: -2.3, trend: "down", helperText: "due to inventory buys" },
+  { title: "Profit Margin", value: "22.3%", change: 1.2, trend: "up", helperText: "target 20%" }
+];
+
+const PERFORMANCE_SERIES: ChartSeries[] = [
+  { key: "revenue", label: "Revenue" },
+  { key: "expenses", label: "Expenses" }
+];
+
+const CASHFLOW_SERIES: ChartSeries[] = [
+  { key: "profit", label: "Profit" },
+  { key: "cashFlow", label: "Cash Flow" }
+];
+
+export function FinancialDashboard({
+  title = "Financial Dashboard",
+  description = "Track revenue, expenses, cash flow, and key KPIs.",
+  className,
+  monthlyMetrics = DEFAULT_MONTHLY_DATA,
+  performanceSeries = PERFORMANCE_SERIES,
+  cashflowSeries = CASHFLOW_SERIES,
+  accountBreakdown = DEFAULT_ACCOUNTS,
+  kpis = DEFAULT_KPIS,
+  refreshable = true,
+  exportable = true,
+  onRefresh,
+  onExport
+}: FinancialDashboardProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const totals = useMemo(() => {
+    const latest = monthlyMetrics[monthlyMetrics.length - 1] ?? {};
+    const cumulativeRevenue = monthlyMetrics.reduce((sum, point) => sum + Number(point.revenue ?? 0), 0);
+    return {
+      latestRevenue: latest.revenue ?? 0,
+      latestProfit: latest.profit ?? 0,
+      cumulativeRevenue
+    };
+  }, [monthlyMetrics]);
+
+  const handleRefresh = async () => {
+    if (!refreshable) {
+      return;
+    }
+    setIsRefreshing(true);
+    try {
+      await onRefresh?.();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const handleExport = () => {
+    onExport?.();
+  };
+
+  return (
+    <Card className={cn("w-full", className)} data-testid="financial-dashboard">
+      <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <CardTitle className="text-xl">{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </div>
+        <div className="flex gap-2">
+          {refreshable && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleRefresh}
+              aria-live="polite"
+              aria-busy={isRefreshing}
+            >
+              <RefreshCw className={cn("h-4 w-4", isRefreshing && "animate-spin")} />
+              <span className="ml-2">{isRefreshing ? "Refreshing..." : "Refresh Data"}</span>
+            </Button>
+          )}
+          {exportable && (
+            <Button type="button" onClick={handleExport}>
+              <Download className="h-4 w-4" />
+              <span className="ml-2">Export CSV</span>
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {kpis.map((kpi) => (
+            <div
+              key={kpi.title}
+              className="rounded-lg border border-gray-200 bg-white p-4"
+              role="group"
+              aria-label={`${kpi.title} KPI`}
+            >
+              <div className="text-sm text-muted-foreground">{kpi.title}</div>
+              <div className="mt-1 text-2xl font-semibold text-foreground">{kpi.value}</div>
+              <div className="mt-2 flex items-center gap-2 text-sm">
+                {kpi.trend === "up" ? (
+                  <TrendingUp className="h-4 w-4 text-emerald-500" />
+                ) : (
+                  <TrendingDown className="h-4 w-4 text-rose-500" />
+                )}
+                <span className={kpi.trend === "up" ? "text-emerald-600" : "text-rose-600"}>
+                  {kpi.trend === "up" ? "+" : ""}
+                  {kpi.change}%
+                </span>
+                {kpi.helperText && <span className="text-muted-foreground">{kpi.helperText}</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <LineChart
+              title="Revenue vs Expenses"
+              description="Monthly performance over the last six periods."
+              data={monthlyMetrics}
+              series={performanceSeries}
+              xAxisKey="month"
+              showCard={false}
+              className="rounded-xl border border-gray-200 bg-white p-4"
+              formatValue={(value) =>
+                new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value)
+              }
+            />
+          </div>
+          <div>
+            <PieChart
+              title="Account Breakdown"
+              description="Share of key account balances."
+              segments={accountBreakdown}
+              showCard={false}
+              className="rounded-xl border border-gray-200 bg-white p-4"
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <BarChart
+            title="Profit & Cash Flow"
+            description="Compare liquidity to operating performance."
+            data={monthlyMetrics}
+            series={cashflowSeries}
+            xAxisKey="month"
+            showCard={false}
+            className="rounded-xl border border-gray-200 bg-white p-4"
+            formatValue={(value) =>
+              new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(
+                value
+              )
+            }
+          />
+          <DoughnutChart
+            title="Working Capital"
+            description="Asset allocation snapshot."
+            segments={accountBreakdown}
+            showCard={false}
+            className="rounded-xl border border-gray-200 bg-white p-4"
+          />
+        </div>
+
+        <div
+          className="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          Latest month revenue:{" "}
+          <span className="font-semibold text-foreground">
+            $
+            {Number(totals.latestRevenue).toLocaleString()}
+          </span>
+          , profit{" "}
+          <span className="font-semibold text-foreground">
+            ${Number(totals.latestProfit).toLocaleString()}
+          </span>
+          . Six-month revenue total:{" "}
+          <span className="font-semibold text-foreground">
+            ${Number(totals.cumulativeRevenue).toLocaleString()}
+          </span>
+          .
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/charts/LineChart.test.tsx
+++ b/components/charts/LineChart.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+
+import { LineChart } from './LineChart';
+
+const sampleData = [
+  { month: 'Jan', revenue: 12000, expenses: 8000 },
+  { month: 'Feb', revenue: 15000, expenses: 9000 }
+];
+
+const sampleSeries = [
+  { key: 'revenue', label: 'Revenue' },
+  { key: 'expenses', label: 'Expenses' }
+];
+
+describe('LineChart', () => {
+  it('renders a line chart with provided data and labels', () => {
+    render(
+      <LineChart
+        title="Revenue Trends"
+        description="Track month over month performance"
+        data={sampleData}
+        series={sampleSeries}
+        ariaLabel="Revenue line chart"
+      />
+    );
+
+    expect(screen.getByRole('img', { name: /revenue line chart/i })).toBeInTheDocument();
+    expect(screen.getByText('Revenue')).toBeInTheDocument();
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+  });
+});

--- a/components/charts/LineChart.tsx
+++ b/components/charts/LineChart.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo } from "react";
+import { CartesianGrid, Line, LineChart as RechartsLineChart, XAxis, YAxis } from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import { buildChartConfig, type ChartDataPoint, type ChartSeries } from "./chart-types";
+
+export interface LineChartProps {
+  title?: string;
+  description?: string;
+  data: ChartDataPoint[];
+  series: ChartSeries[];
+  xAxisKey?: string;
+  showCard?: boolean;
+  showLegend?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  height?: number;
+  className?: string;
+  ariaLabel?: string;
+  formatValue?: (value: number) => string;
+}
+
+const DEFAULT_LINE_VALUE = (value: number) => value.toLocaleString();
+
+export function LineChart({
+  title,
+  description,
+  data,
+  series,
+  xAxisKey = "label",
+  showCard = true,
+  showLegend = true,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = true,
+  height = 340,
+  className,
+  ariaLabel,
+  formatValue = DEFAULT_LINE_VALUE
+}: LineChartProps) {
+  const chartConfig = useMemo(() => buildChartConfig(series), [series]);
+  const containerLabel = ariaLabel ?? `${title ?? "Line"} chart showing ${series.length} series`;
+
+  const chart = (
+    <figure className={cn("space-y-3", showCard ? "" : className)}>
+      {!showCard && (title || description) && (
+        <div className="space-y-1">
+          {title && <p className="text-base font-semibold text-foreground">{title}</p>}
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+      )}
+      <ChartContainer
+        role="img"
+        aria-label={containerLabel}
+        config={chartConfig}
+        className="w-full rounded-xl border border-gray-100 bg-white"
+        style={{ height }}
+        data-testid="line-chart"
+      >
+        <RechartsLineChart
+          data={data}
+          margin={{
+            top: 16,
+            right: 16,
+            left: 16,
+            bottom: 16
+          }}
+        >
+          {showGrid && (
+            <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
+          )}
+          {showXAxis && (
+            <XAxis dataKey={xAxisKey} tickLine={false} axisLine={false} className="text-xs" />
+          )}
+          {showYAxis && (
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              className="text-xs"
+              tickFormatter={(value) => formatValue(Number(value))}
+            />
+          )}
+          <ChartTooltip
+            cursor={false}
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => [
+                  formatValue(Number(value)),
+                  series.find((item) => item.key === name)?.label ?? name
+                ]}
+              />
+            }
+          />
+          {series.map((item) => (
+            <Line
+              key={item.key}
+              type="monotone"
+              dataKey={item.key}
+              stroke={`var(--color-${item.key})`}
+              strokeWidth={2}
+              dot={false}
+              aria-label={`${item.label} data series`}
+            />
+          ))}
+          {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        </RechartsLineChart>
+      </ChartContainer>
+    </figure>
+  );
+
+  if (!showCard) {
+    return chart;
+  }
+
+  return (
+    <Card className={cn("w-full", className)}>
+      {(title || description) && (
+        <CardHeader className="space-y-1">
+          {title && <CardTitle className="text-base">{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/charts/PieChart.test.tsx
+++ b/components/charts/PieChart.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+
+import { PieChart } from './PieChart';
+
+const segments = [
+  { id: 'cash', label: 'Cash', value: 4200 },
+  { id: 'inventory', label: 'Inventory', value: 2100 },
+  { id: 'equipment', label: 'Equipment', value: 6000 }
+];
+
+describe('PieChart', () => {
+  it('renders segment labels from props', () => {
+    render(<PieChart title="Asset Mix" segments={segments} ariaLabel="Asset pie chart" />);
+
+    expect(screen.getByRole('img', { name: /asset pie chart/i })).toBeInTheDocument();
+    expect(screen.getByText('Cash')).toBeInTheDocument();
+    expect(screen.getByText('Inventory')).toBeInTheDocument();
+  });
+});

--- a/components/charts/PieChart.tsx
+++ b/components/charts/PieChart.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useMemo } from "react";
+import { Cell, Pie, PieChart as RechartsPieChart } from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import {
+  buildChartConfig,
+  type ChartSegment,
+  DEFAULT_CHART_COLORS,
+  formatCurrency
+} from "./chart-types";
+
+export interface PieChartProps {
+  title?: string;
+  description?: string;
+  segments: ChartSegment[];
+  showCard?: boolean;
+  showLegend?: boolean;
+  className?: string;
+  ariaLabel?: string;
+  height?: number;
+  valueFormatter?: (value: number) => string;
+  showPercentages?: boolean;
+}
+
+export function PieChart({
+  title,
+  description,
+  segments,
+  showCard = true,
+  showLegend = true,
+  className,
+  ariaLabel,
+  height = 340,
+  valueFormatter = (value) => formatCurrency(value),
+  showPercentages = true
+}: PieChartProps) {
+  const chartConfig = useMemo(
+    () =>
+      buildChartConfig(
+        segments.map((segment, index) => ({
+          key: segment.id,
+          label: segment.label,
+          color: segment.color ?? DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length]
+        }))
+      ),
+    [segments]
+  );
+
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+  const data = segments.map((segment, index) => ({
+    name: segment.label,
+    value: segment.value,
+    key: segment.id,
+    fill: segment.color ?? DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length],
+    percentage: total > 0 ? (segment.value / total) * 100 : 0
+  }));
+
+  const containerLabel =
+    ariaLabel ?? `${title ?? "Pie"} chart showing ${segments.length} categories`;
+
+  const chart = (
+    <figure className={cn("space-y-3", showCard ? "" : className)}>
+      {!showCard && (title || description) && (
+        <div className="space-y-1">
+          {title && <p className="text-base font-semibold text-foreground">{title}</p>}
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+      )}
+      <ChartContainer
+        role="img"
+        aria-label={containerLabel}
+        config={chartConfig}
+        className="w-full rounded-xl border border-gray-100 bg-white"
+        style={{ height }}
+        data-testid="pie-chart"
+      >
+        <RechartsPieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            outerRadius="80%"
+            paddingAngle={2}
+          >
+            {data.map((entry) => (
+              <Cell key={entry.key} fill={entry.fill} stroke="rgba(255,255,255,0.8)" />
+            ))}
+          </Pie>
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => {
+                  const percentage = data.find((item) => item.name === name)?.percentage ?? 0;
+                  return [
+                    showPercentages
+                      ? `${valueFormatter(Number(value))} (${percentage.toFixed(1)}%)`
+                      : valueFormatter(Number(value)),
+                    name
+                  ];
+                }}
+                labelFormatter={() => ""}
+                indicator="dot"
+              />
+            }
+          />
+          {showLegend && (
+            <ChartLegend
+              content={<ChartLegendContent />}
+              verticalAlign="bottom"
+              height={36}
+            />
+          )}
+        </RechartsPieChart>
+      </ChartContainer>
+    </figure>
+  );
+
+  if (!showCard) {
+    return chart;
+  }
+
+  return (
+    <Card className={cn("w-full", className)}>
+      {(title || description) && (
+        <CardHeader className="space-y-1">
+          {title && <CardTitle className="text-base">{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/charts/chart-types.ts
+++ b/components/charts/chart-types.ts
@@ -1,0 +1,44 @@
+import type { ChartConfig } from "@/components/ui/chart";
+
+export interface ChartSeries {
+  key: string;
+  label: string;
+  color?: string;
+}
+
+export interface ChartDataPoint {
+  [key: string]: string | number | null | undefined;
+}
+
+export interface ChartSegment {
+  id: string;
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export const DEFAULT_CHART_COLORS = [
+  "hsl(222, 47%, 11%)",
+  "hsl(210, 84%, 53%)",
+  "hsl(142, 70%, 45%)",
+  "hsl(6, 78%, 57%)",
+  "hsl(27, 96%, 55%)",
+  "hsl(271, 90%, 65%)"
+];
+
+export function buildChartConfig(series: ChartSeries[]): ChartConfig {
+  return series.reduce<ChartConfig>((config, item, index) => {
+    config[item.key] = {
+      label: item.label,
+      color: item.color ?? DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length]
+    };
+    return config;
+  }, {});
+}
+
+export const formatCurrency = (value: number, currency = "USD") =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0
+  }).format(value);

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "@/lib/utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-surface]:outline-hidden [&_.recharts-layer]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-dot[stroke='#fff']]:stroke-transparent flex aspect-video justify-center text-xs",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(([, value]) => value.theme || value.color);
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n")
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+type ChartTooltipContentProps = React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+    label?: React.ReactNode;
+    labelFormatter?: (value: React.ReactNode, payload?: unknown[]) => React.ReactNode;
+    formatter?: (
+      value: number,
+      name?: string | number,
+      entry?: unknown,
+      index?: number,
+      payload?: unknown
+    ) => React.ReactNode;
+    payload?: Array<Record<string, unknown>>;
+  };
+
+function ChartTooltipContent({
+  active,
+  payload = [],
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey
+}: ChartTooltipContentProps) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const payloadColor =
+            item.payload && typeof item.payload === "object" && "fill" in item.payload
+              ? (item.payload as { fill?: string }).fill
+              : undefined;
+          const indicatorColor = color || payloadColor || item.color;
+
+          return (
+            <div
+              key={`${item.dataKey ?? index}`}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                indicator === "dot" ? "items-center" : "items-stretch"
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(
+                  typeof item.value === "number" ? item.value : Number(item.value),
+                  (item.name ?? item.dataKey ?? "value") as string,
+                  item,
+                  index,
+                  item.payload
+                )
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed"
+                          }
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center"
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label ||
+                          (typeof item.name === "string" ? item.name : String(item.name ?? key))}
+                      </span>
+                    </div>
+                    {item.value !== undefined && item.value !== null && !Number.isNaN(Number(item.value)) && (
+                      <span className="text-foreground font-mono font-medium tabular-nums">
+                        {Number(item.value).toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+type LegendContentPayload = Array<{
+  dataKey?: string | number;
+  color?: string;
+  value?: string | number;
+  payload?: Record<string, unknown>;
+}>;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload = [],
+  verticalAlign = "bottom",
+  nameKey
+}: React.ComponentProps<"div"> & {
+  hideIcon?: boolean;
+  nameKey?: string;
+  payload?: LegendContentPayload;
+  verticalAlign?: "top" | "middle" | "bottom";
+}) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className="[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
+}
+
+export { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, ChartStyle };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "postgres": "^3.4.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^3.3.0",
         "tailwind-merge": "^3.3.0",
         "zod": "^4.1.12"
       },
@@ -3058,6 +3059,32 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
+      "integrity": "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.2.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3387,6 +3414,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.79.0.tgz",
@@ -3651,6 +3690,69 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5269,6 +5371,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5376,6 +5599,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -5888,6 +6117,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.41.0.tgz",
+      "integrity": "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -6398,6 +6637,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -7040,6 +7285,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7090,6 +7345,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8835,7 +9099,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -8973,6 +9236,33 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.3.0.tgz",
+      "integrity": "sha512-Vi0qmTB0iz1+/Cz9o5B7irVyUjX2ynvEgImbgMt/3sKRREcUM07QiYjS1QpAVrkmVlXqy5gykq4nGWMz9AS4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -8992,6 +9282,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9036,6 +9335,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10469,6 +10774,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postgres": "^3.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.3.0",
     "tailwind-merge": "^3.3.0",
     "zod": "^4.1.12"
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -5,3 +5,35 @@ import { cleanup } from '@testing-library/react';
 afterEach(() => {
   cleanup();
 });
+
+class ResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          contentRect: {
+            width: (target as HTMLElement).clientWidth || 600,
+            height: (target as HTMLElement).clientHeight || 400
+          }
+        } as ResizeObserverEntry
+      ],
+      this
+    );
+  }
+
+  unobserve() {
+    // no-op
+  }
+
+  disconnect() {
+    // no-op
+  }
+}
+
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = ResizeObserver;


### PR DESCRIPTION
## Summary\n- add shared recharts container utilities plus typed chart series helpers\n- migrate six chart + dashboard components to Supabase-friendly props with accessibility\n- cover new components with Vitest suites and ResizeObserver polyfill\n\n## Testing\n- npm run test\n- npm run lint\n- npm run build\n\nResolves #33