### PR TITLE
feat: migrate business simulations part a

### DIFF
--- a/components/business-simulations/BudgetBalancer.test.tsx
+++ b/components/business-simulations/BudgetBalancer.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BudgetBalancer, type BudgetBalancerActivity, type BudgetBalancerState } from './BudgetBalancer'
+import type { BudgetBalancerActivityProps } from '@/lib/db/schema/activities'
+
+const defaultBudgetProps: BudgetBalancerActivityProps = {
+  title: 'Budget Balancer',
+  description: 'Learn to balance income and expenses each month.',
+  expenses: [
+    { id: 'rent', label: 'Rent', required: true, defaultAmount: 1200, icon: 'home', color: 'bg-blue-500' },
+    { id: 'utilities', label: 'Utilities', required: true, defaultAmount: 300, icon: 'zap', color: 'bg-yellow-500' },
+    { id: 'groceries', label: 'Groceries', required: true, defaultAmount: 400, icon: 'shopping-cart', color: 'bg-green-500' },
+    { id: 'transportation', label: 'Transportation', required: true, defaultAmount: 200, icon: 'car', color: 'bg-purple-500' },
+    { id: 'entertainment', label: 'Entertainment', required: false, defaultAmount: 0, icon: 'coffee', color: 'bg-pink-500' }
+  ],
+  savingsConfig: {
+    emergencyFundContributionRate: 0.1,
+    healthScoreBase: 50,
+    savingsMultiplier: 50,
+    emergencyMultiplier: 25
+  },
+  initialState: {
+    monthlyIncome: 5000,
+    month: 1,
+    totalSavings: 1000,
+    emergencyFund: 500,
+    financialHealth: 100
+  }
+}
+
+const buildActivity = (overrides: Partial<BudgetBalancerActivityProps> = {}): BudgetBalancerActivity => {
+  const props: BudgetBalancerActivityProps = {
+    ...defaultBudgetProps,
+    ...overrides,
+    expenses: overrides.expenses ?? defaultBudgetProps.expenses,
+    savingsConfig: overrides.savingsConfig ?? defaultBudgetProps.savingsConfig,
+    initialState: {
+      ...defaultBudgetProps.initialState,
+      ...(overrides.initialState ?? {})
+    }
+  }
+
+  return {
+    id: 'activity-budget',
+    componentKey: 'budget-balancer',
+    displayName: 'Budget Balancer',
+    description: 'Plan monthly finances.',
+    props,
+    gradingConfig: null,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+}
+
+describe('BudgetBalancer', () => {
+  it('shows income from persisted state overrides', async () => {
+    const activity = buildActivity()
+    const initialState: Partial<BudgetBalancerState> = {
+      monthlyIncome: 6500
+    }
+
+    render(<BudgetBalancer activity={activity} initialState={initialState} />)
+
+    expect(await screen.findByText('$6,500')).toBeInTheDocument()
+  })
+
+  it('applies expense updates and calls onStateChange', async () => {
+    const onStateChange = vi.fn()
+    const activity = buildActivity()
+
+    render(<BudgetBalancer activity={activity} onStateChange={onStateChange} />)
+
+    await waitFor(() => expect(onStateChange).toHaveBeenCalled())
+
+    const inputs = await screen.findAllByRole('spinbutton')
+    const updateButtons = await screen.findAllByRole('button', { name: /update/i })
+    await userEvent.clear(inputs[0])
+    await userEvent.type(inputs[0], '1500')
+    await userEvent.click(updateButtons[0])
+
+    await waitFor(() => expect(onStateChange.mock.calls.at(-1)?.[0].expenses.rent.amount).toBe(1500))
+  })
+})

--- a/components/business-simulations/BudgetBalancer.tsx
+++ b/components/business-simulations/BudgetBalancer.tsx
@@ -1,0 +1,706 @@
+/**
+ * BudgetBalancer Component
+ * 
+ * DEVELOPER USAGE:
+ * ================
+ * Import and use this component in any React page or component:
+ * 
+ * ```tsx
+ * import { BudgetBalancer } from '@/components/business-simulations/BudgetBalancer'
+ * 
+ * export default function MyPage() {
+ *   return (
+ *     <div>
+ *       <BudgetBalancer />
+ *     </div>
+ *   )
+ * }
+ * ```
+ * 
+ * The component is fully self-contained with its own state management.
+ * No props are required - it initializes with default values.
+ * 
+ * STUDENT INTERACTION & LEARNING OBJECTIVES:
+ * ==========================================
+ * 
+ * OBJECTIVE: Students learn personal finance management, budgeting skills, 
+ * and the impact of spending decisions on financial health.
+ * 
+ * HOW STUDENTS INTERACT:
+ * 1. **View Financial Dashboard**: Students see their monthly income ($5,000), 
+ *    current month, total savings, and financial health score.
+ * 
+ * 2. **Manage Expenses**: Students can adjust monthly expenses in two categories:
+ *    - REQUIRED expenses (rent, utilities, groceries, transportation) - must be paid
+ *    - OPTIONAL expenses (entertainment, dining, shopping) - discretionary spending
+ * 
+ * 3. **Make Budget Decisions**: 
+ *    - Enter amounts for each expense category
+ *    - See real-time budget calculations and remaining budget
+ *    - Get visual feedback when over/under budget
+ * 
+ * 4. **Advance Through Months**: Click "End Month" to progress and see results:
+ *    - Savings accumulate from positive budget balance
+ *    - Emergency fund grows automatically (10% of surplus)
+ *    - Financial health score updates based on savings rate and spending habits
+ * 
+ * 5. **Learn From Consequences**:
+ *    - Going over budget prevents month advancement
+ *    - Low savings rate reduces financial health score
+ *    - Students see long-term impact of spending decisions
+ * 
+ * KEY LEARNING OUTCOMES:
+ * - Understanding fixed vs. variable expenses
+ * - Importance of emergency funds and savings
+ * - How spending decisions affect financial stability
+ * - Real-time budget tracking and adjustment skills
+ * - Long-term financial planning and health monitoring
+ */
+
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import {
+  type LucideIcon,
+  DollarSign, 
+  Calendar, 
+  PiggyBank, 
+  Heart,
+  Home,
+  Zap,
+  ShoppingCart,
+  Car,
+  Coffee,
+  Utensils,
+  ShoppingBag,
+  TrendingUp,
+  AlertTriangle,
+  HelpCircle,
+  ChevronDown,
+  ChevronUp
+} from 'lucide-react'
+
+import type { Activity } from '@/lib/db/schema/validators'
+import type { BudgetBalancerActivityProps } from '@/lib/db/schema/activities'
+
+export type BudgetBalancerActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'budget-balancer'
+  props: BudgetBalancerActivityProps
+}
+
+export interface BudgetBalancerExpense {
+  amount: number
+  required: boolean
+  paid: boolean
+  iconKey: string
+  color: string
+}
+
+export interface BudgetBalancerState {
+  monthlyIncome: number
+  month: number
+  totalSavings: number
+  expenses: Record<string, BudgetBalancerExpense>
+  emergencyFund: number
+  financialHealth: number
+}
+
+interface BudgetBalancerProps {
+  activity: BudgetBalancerActivity
+  initialState?: Partial<BudgetBalancerState>
+  onStateChange?: (state: BudgetBalancerState) => void
+}
+
+const EXPENSE_ICONS: Record<string, LucideIcon> = {
+  home: Home,
+  zap: Zap,
+  'shopping-cart': ShoppingCart,
+  car: Car,
+  coffee: Coffee,
+  utensils: Utensils,
+  'shopping-bag': ShoppingBag
+}
+
+const buildExpenseState = (expenses: BudgetBalancerActivityProps['expenses']): Record<string, BudgetBalancerExpense> =>
+  Object.fromEntries(
+    expenses.map((expense) => [
+      expense.id,
+      {
+        amount: expense.defaultAmount,
+        required: expense.required,
+        paid: false,
+        iconKey: expense.icon,
+        color: expense.color
+      }
+    ])
+  )
+
+const cloneExpenses = (expenses: Record<string, BudgetBalancerExpense>): Record<string, BudgetBalancerExpense> =>
+  Object.fromEntries(
+    Object.entries(expenses).map(([key, expense]) => [
+      key,
+      { ...expense }
+    ])
+  )
+
+const cloneBudgetStateFromConfig = (
+  state: BudgetBalancerActivityProps['initialState'],
+  expenses: BudgetBalancerActivityProps['expenses']
+): BudgetBalancerState => ({
+  monthlyIncome: state.monthlyIncome,
+  month: state.month,
+  totalSavings: state.totalSavings,
+  expenses: buildExpenseState(expenses),
+  emergencyFund: state.emergencyFund,
+  financialHealth: state.financialHealth
+})
+
+const mergeBudgetState = (
+  base: BudgetBalancerState,
+  override?: Partial<BudgetBalancerState>
+): BudgetBalancerState => {
+  const mergedExpenses = cloneExpenses(base.expenses)
+
+  if (override?.expenses) {
+    Object.entries(override.expenses).forEach(([key, expense]) => {
+      mergedExpenses[key] = {
+        ...(mergedExpenses[key] ?? {
+          amount: 0,
+          required: expense.required ?? false,
+          paid: false,
+          iconKey: expense.iconKey ?? 'home',
+          color: expense.color ?? 'bg-gray-500'
+        }),
+        ...expense
+      }
+    })
+  }
+
+  return {
+    monthlyIncome: override?.monthlyIncome ?? base.monthlyIncome,
+    month: override?.month ?? base.month,
+    totalSavings: override?.totalSavings ?? base.totalSavings,
+    expenses: mergedExpenses,
+    emergencyFund: override?.emergencyFund ?? base.emergencyFund,
+    financialHealth: override?.financialHealth ?? base.financialHealth
+  }
+}
+
+export function BudgetBalancer({ activity, initialState, onStateChange }: BudgetBalancerProps) {
+  const baseState = useMemo(
+    () => cloneBudgetStateFromConfig(activity.props.initialState, activity.props.expenses),
+    [activity.props.initialState, activity.props.expenses]
+  )
+  const [gameState, setGameState] = useState<BudgetBalancerState>(() => mergeBudgetState(baseState, initialState))
+  const [tempExpenses, setTempExpenses] = useState<Record<string, number>>(() =>
+    Object.fromEntries(Object.entries(gameState.expenses).map(([key, expense]) => [key, expense.amount]))
+  )
+
+  const [showInstructions, setShowInstructions] = useState(false)
+
+  useEffect(() => {
+    const merged = mergeBudgetState(baseState, initialState)
+    setGameState(merged)
+    setTempExpenses(Object.fromEntries(Object.entries(merged.expenses).map(([key, expense]) => [key, expense.amount])))
+  }, [baseState, initialState])
+
+  useEffect(() => {
+    onStateChange?.(gameState)
+  }, [gameState, onStateChange])
+
+  const totalExpenses = Object.values(gameState.expenses).reduce((sum, expense) => sum + expense.amount, 0)
+  const remainingBudget = gameState.monthlyIncome - totalExpenses
+  const requiredExpenses = Object.values(gameState.expenses)
+    .filter(expense => expense.required)
+    .reduce((sum, expense) => sum + expense.amount, 0)
+
+  const updateExpense = (expenseKey: string, newAmount: number) => {
+    setTempExpenses(prev => ({
+      ...prev,
+      [expenseKey]: Math.max(0, newAmount)
+    }))
+  }
+
+  const applyExpenseChanges = () => {
+    setGameState(prev => ({
+      ...prev,
+      expenses: Object.fromEntries(
+        Object.entries(prev.expenses).map(([key, expense]) => [
+          key, 
+          { ...expense, amount: tempExpenses[key] || 0 }
+        ])
+      )
+    }))
+  }
+
+  const advanceMonth = () => {
+    const newRemaining = gameState.monthlyIncome - totalExpenses
+    const newSavings = gameState.totalSavings + Math.max(0, newRemaining)
+    
+    // Calculate financial health based on savings rate and emergency fund
+    const savingsRate = newRemaining / gameState.monthlyIncome
+    const emergencyFundRatio = gameState.emergencyFund / gameState.monthlyIncome
+    const { emergencyFundContributionRate, healthScoreBase, savingsMultiplier, emergencyMultiplier } =
+      activity.props.savingsConfig
+    const healthScore = Math.max(
+      0,
+      Math.min(100, healthScoreBase + savingsRate * savingsMultiplier + emergencyFundRatio * emergencyMultiplier)
+    )
+    const emergencyContribution = Math.max(0, newRemaining * emergencyFundContributionRate)
+
+    setGameState(prev => ({
+      ...prev,
+      month: prev.month + 1,
+      totalSavings: newSavings,
+      emergencyFund: prev.emergencyFund + emergencyContribution,
+      financialHealth: Math.round(healthScore),
+      expenses: Object.fromEntries(
+        Object.entries(prev.expenses).map(([key, expense]) => [
+          key, 
+          { ...expense, paid: false }
+        ])
+      )
+    }))
+  }
+
+  const resetGame = () => {
+    const resetState = cloneBudgetStateFromConfig(activity.props.initialState, activity.props.expenses)
+    setGameState(resetState)
+    setTempExpenses(Object.fromEntries(Object.entries(resetState.expenses).map(([key, expense]) => [key, expense.amount])))
+  }
+
+  const getHealthColor = (health: number) => {
+    if (health >= 80) return 'text-green-600'
+    if (health >= 60) return 'text-yellow-600'
+    if (health >= 40) return 'text-orange-600'
+    return 'text-red-600'
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      {/* Header */}
+      <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 border-blue-200">
+        <CardHeader className="text-center">
+          <CardTitle className="text-3xl flex items-center justify-center gap-2">
+            <DollarSign className="w-8 h-8 text-blue-600" />
+            {activity.props.title}
+          </CardTitle>
+          <CardDescription className="text-lg">
+            {activity.description ?? activity.props.description}
+          </CardDescription>
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowInstructions(!showInstructions)}
+              className="flex items-center gap-2"
+            >
+              <HelpCircle className="w-4 h-4" />
+              How to Play
+              {showInstructions ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Instructions Panel */}
+      {showInstructions && (
+        <Card className="border-blue-200 bg-blue-50">
+          <CardHeader>
+            <CardTitle className="text-xl text-blue-800 flex items-center gap-2">
+              <HelpCircle className="w-5 h-5" />
+              {`How to Play ${activity.props.title}`}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Objective */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-2">🎯 Objective</h4>
+              <p className="text-blue-700">
+                Learn personal finance management by balancing your monthly budget. Start with $
+                {activity.props.initialState.monthlyIncome.toLocaleString()} in monthly income 
+                and make smart decisions about required and optional expenses to build savings and maintain financial health.
+              </p>
+            </div>
+
+            {/* How to Play */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-3">🎮 How to Play</h4>
+              <div className="space-y-3">
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-1">1. Monitor Your Dashboard</h5>
+                  <p className="text-sm text-gray-600">
+                    Track your monthly income (${activity.props.initialState.monthlyIncome.toLocaleString()}), current month, total savings, and financial health score (0-100%).
+                  </p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-1">2. Manage Monthly Expenses</h5>
+                  <p className="text-sm text-gray-600">Adjust spending in two categories: <strong>Required</strong> expenses (rent, utilities, groceries, transportation) and <strong>Optional</strong> expenses (entertainment, dining, shopping).</p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-1">3. Make Budget Decisions</h5>
+                  <p className="text-sm text-gray-600">Enter amounts for each expense category, see real-time budget calculations, and get visual feedback when over/under budget.</p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-1">4. Advance Through Months</h5>
+                  <p className="text-sm text-gray-600">
+                    Click &quot;End Month&quot; to progress. Savings accumulate from positive budget balance, emergency fund grows (10% of surplus), and financial health updates.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Expense Categories */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-3">💰 Expense Categories</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="p-3 bg-orange-50 rounded-lg border border-orange-200">
+                  <h5 className="font-medium text-orange-800 mb-2">🏠 Required Expenses (Must Pay)</h5>
+                  <ul className="text-sm text-orange-700 space-y-1">
+                    <li>• <strong>Rent:</strong> $1,200 (housing)</li>
+                    <li>• <strong>Utilities:</strong> $300 (electricity, water, internet)</li>
+                    <li>• <strong>Groceries:</strong> $400 (food essentials)</li>
+                    <li>• <strong>Transportation:</strong> $200 (car, gas, public transit)</li>
+                  </ul>
+                </div>
+                <div className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+                  <h5 className="font-medium text-blue-800 mb-2">🎉 Optional Expenses (Your Choice)</h5>
+                  <ul className="text-sm text-blue-700 space-y-1">
+                    <li>• <strong>Entertainment:</strong> Movies, games, subscriptions</li>
+                    <li>• <strong>Dining Out:</strong> Restaurants, takeout, coffee</li>
+                    <li>• <strong>Shopping:</strong> Clothes, gadgets, non-essentials</li>
+                    <li>• <em>Start at $0 - you decide how much to spend!</em></li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Financial Health */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-3">💚 Financial Health Score</h4>
+              <div className="grid grid-cols-4 gap-2 text-xs">
+                <div className="p-2 bg-green-100 rounded text-center">
+                  <div className="font-medium text-green-800">Excellent</div>
+                  <div className="text-green-600">80-100%</div>
+                </div>
+                <div className="p-2 bg-yellow-100 rounded text-center">
+                  <div className="font-medium text-yellow-800">Good</div>
+                  <div className="text-yellow-600">60-79%</div>
+                </div>
+                <div className="p-2 bg-orange-100 rounded text-center">
+                  <div className="font-medium text-orange-800">Fair</div>
+                  <div className="text-orange-600">40-59%</div>
+                </div>
+                <div className="p-2 bg-red-100 rounded text-center">
+                  <div className="font-medium text-red-800">Poor</div>
+                  <div className="text-red-600">0-39%</div>
+                </div>
+              </div>
+              <p className="text-sm text-blue-700 mt-2">
+                <strong>Health factors:</strong> Savings rate (50%), emergency fund ratio (25%), and baseline financial stability (25%)
+              </p>
+            </div>
+
+            {/* Key Learning Goals */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-2">🎓 Key Learning Goals</h4>
+              <ul className="text-sm text-blue-700 space-y-1">
+                <li>• <strong>Fixed vs. Variable Expenses:</strong> Understanding required vs. optional spending</li>
+                <li>• <strong>Emergency Fund Building:</strong> 10% of surplus automatically goes to emergency savings</li>
+                <li>• <strong>Budget Impact:</strong> See how spending decisions affect long-term financial stability</li>
+                <li>• <strong>Real-time Tracking:</strong> Practice budget monitoring and adjustment skills</li>
+                <li>• <strong>Financial Planning:</strong> Learn to balance current enjoyment with future security</li>
+              </ul>
+            </div>
+
+            {/* Success Tips */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-2">💡 Success Tips</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+                  <h5 className="font-medium text-green-800 mb-1">Conservative Strategy</h5>
+                  <ul className="text-xs text-green-700 space-y-1">
+                    <li>• Keep optional expenses low initially</li>
+                    <li>• Focus on building emergency fund first</li>
+                    <li>• Aim for 20%+ savings rate</li>
+                    <li>• Gradually increase lifestyle spending</li>
+                  </ul>
+                </div>
+                <div className="p-3 bg-orange-50 rounded-lg border border-orange-200">
+                  <h5 className="font-medium text-orange-800 mb-1">Balanced Approach</h5>
+                  <ul className="text-xs text-orange-700 space-y-1">
+                    <li>• Set moderate optional expense budgets</li>
+                    <li>• Monitor financial health regularly</li>
+                    <li>• Adjust spending based on health score</li>
+                    <li>• Balance enjoyment with saving goals</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Sample Budget */}
+            <div>
+              <h4 className="font-semibold text-blue-800 mb-3">
+                📊 Sample Monthly Budget (based on ${activity.props.initialState.monthlyIncome.toLocaleString()} income)
+              </h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-2">💰 Income & Required</h5>
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between">
+                      <span>Monthly Income:</span>
+                      <span className="text-green-600 font-medium">
+                        +${activity.props.initialState.monthlyIncome.toLocaleString()}
+                      </span>
+                    </div>
+                    <div className="flex justify-between"><span>Rent:</span><span className="text-red-600">-$1,200</span></div>
+                    <div className="flex justify-between"><span>Utilities:</span><span className="text-red-600">-$300</span></div>
+                    <div className="flex justify-between"><span>Groceries:</span><span className="text-red-600">-$400</span></div>
+                    <div className="flex justify-between"><span>Transportation:</span><span className="text-red-600">-$200</span></div>
+                    <hr className="my-1" />
+                    <div className="flex justify-between font-medium"><span>After Required:</span><span className="text-blue-600">$2,900</span></div>
+                  </div>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <h5 className="font-medium mb-2">🎯 Smart Optional Spending</h5>
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between"><span>Entertainment:</span><span className="text-gray-600">-$200</span></div>
+                    <div className="flex justify-between"><span>Dining Out:</span><span className="text-gray-600">-$300</span></div>
+                    <div className="flex justify-between"><span>Shopping:</span><span className="text-gray-600">-$150</span></div>
+                    <hr className="my-1" />
+                    <div className="flex justify-between"><span>Total Optional:</span><span className="text-gray-600">-$650</span></div>
+                    <div className="flex justify-between font-medium"><span>Monthly Savings:</span><span className="text-green-600">$2,250</span></div>
+                    <div className="flex justify-between text-xs"><span>Emergency Fund:</span><span className="text-purple-600">+$225</span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Game Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="bg-gradient-to-br from-green-50 to-green-100 border-green-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <DollarSign className="w-6 h-6 text-green-600" />
+            </div>
+            <p className="text-sm text-green-700 font-medium">Income</p>
+            <p className="text-2xl font-bold text-green-800">
+              ${gameState.monthlyIncome.toLocaleString()}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <Calendar className="w-6 h-6 text-blue-600" />
+            </div>
+            <p className="text-sm text-blue-700 font-medium">Month</p>
+            <p className="text-2xl font-bold text-blue-800">{gameState.month}</p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-purple-50 to-purple-100 border-purple-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <PiggyBank className="w-6 h-6 text-purple-600" />
+            </div>
+            <p className="text-sm text-purple-700 font-medium">Savings</p>
+            <p className="text-2xl font-bold text-purple-800">
+              ${gameState.totalSavings.toLocaleString()}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-pink-50 to-pink-100 border-pink-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <Heart className={`w-6 h-6 ${getHealthColor(gameState.financialHealth)}`} />
+            </div>
+            <p className="text-sm text-pink-700 font-medium">Financial Health</p>
+            <p className={`text-2xl font-bold ${getHealthColor(gameState.financialHealth)}`}>
+              {gameState.financialHealth}%
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Budget Overview */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="w-5 h-5" />
+            Budget Overview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">Monthly Income:</span>
+            <span className="text-lg font-bold text-green-600">
+              +${gameState.monthlyIncome.toLocaleString()}
+            </span>
+          </div>
+          
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">Total Expenses:</span>
+            <span className="text-lg font-bold text-red-600">
+              -${totalExpenses.toLocaleString()}
+            </span>
+          </div>
+          
+          <Separator />
+          
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">Remaining Budget:</span>
+            <span className={`text-lg font-bold ${remainingBudget >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              ${remainingBudget.toLocaleString()}
+            </span>
+          </div>
+
+          {remainingBudget < 0 && (
+            <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
+              <AlertTriangle className="w-5 h-5 text-red-600" />
+              <span className="text-sm text-red-700">
+                You&apos;re over budget! Reduce expenses or increase income.
+              </span>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <span>Budget Progress</span>
+              <span>{Math.round((totalExpenses / gameState.monthlyIncome) * 100)}%</span>
+            </div>
+            <Progress 
+              value={Math.min(100, (totalExpenses / gameState.monthlyIncome) * 100)}
+              className="h-2"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Expense Management */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Monthly Expenses</CardTitle>
+          <CardDescription>
+            Adjust your monthly expenses. Required expenses must be paid.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {Object.entries(gameState.expenses).map(([key, expense]) => {
+              const Icon = EXPENSE_ICONS[expense.iconKey] ?? DollarSign
+              return (
+                <Card key={key} className={`${expense.required ? 'border-orange-200 bg-orange-50' : 'border-gray-200'}`}>
+                  <CardContent className="p-4">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-2">
+                        <div className={`p-2 rounded-full ${expense.color} text-white`}>
+                          <Icon className="w-4 h-4" />
+                        </div>
+                        <div>
+                          <h4 className="font-medium capitalize">{key.replace(/([A-Z])/g, ' $1')}</h4>
+                          <div className="flex items-center gap-2">
+                            {expense.required && (
+                              <Badge variant="outline" className="text-xs border-orange-300 text-orange-700">
+                                Required
+                              </Badge>
+                            )}
+                            {!expense.required && (
+                              <Badge variant="outline" className="text-xs border-blue-300 text-blue-700">
+                                Optional
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">$</span>
+                      <Input
+                        type="number"
+                        value={tempExpenses[key] || 0}
+                        onChange={(e) => updateExpense(key, parseInt(e.target.value) || 0)}
+                        min="0"
+                        step="50"
+                        className="flex-1"
+                      />
+                      <Button size="sm" onClick={applyExpenseChanges} variant="outline">
+                        Update
+                      </Button>
+                    </div>
+
+                    <div className="mt-2 text-xs text-gray-500">
+                      Current: ${expense.amount.toLocaleString()}
+                    </div>
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Financial Health */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Heart className={`w-5 h-5 ${getHealthColor(gameState.financialHealth)}`} />
+            Financial Health Score
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">Current Score:</span>
+            <span className={`text-2xl font-bold ${getHealthColor(gameState.financialHealth)}`}>
+              {gameState.financialHealth}%
+            </span>
+          </div>
+          
+          <Progress 
+            value={gameState.financialHealth} 
+            className="h-3"
+          />
+          
+          <div className="text-sm text-gray-600 space-y-1">
+            <p>• Savings rate: {((remainingBudget / gameState.monthlyIncome) * 100).toFixed(1)}%</p>
+            <p>• Emergency fund: ${gameState.emergencyFund.toFixed(0)}</p>
+            <p>• Required expenses: ${requiredExpenses.toLocaleString()} ({((requiredExpenses / gameState.monthlyIncome) * 100).toFixed(1)}%)</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Game Actions */}
+      <div className="flex justify-center gap-4">
+        <Button 
+          onClick={advanceMonth} 
+          size="lg"
+          className="bg-blue-600 hover:bg-blue-700"
+          disabled={remainingBudget < 0}
+        >
+          <Calendar className="w-4 h-4 mr-2" />
+          End Month
+        </Button>
+        <Button 
+          onClick={resetGame} 
+          variant="outline" 
+          size="lg"
+        >
+          Reset Game
+        </Button>
+      </div>
+    </div>
+  )
+}
+export default BudgetBalancer

--- a/components/business-simulations/LemonadeStand.test.tsx
+++ b/components/business-simulations/LemonadeStand.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LemonadeStand, type LemonadeStandActivity, type LemonadeStandState } from './LemonadeStand'
+import type { LemonadeStandActivityProps } from '@/lib/db/schema/activities'
+
+const defaultLemonadeProps: LemonadeStandActivityProps = {
+  title: 'Lemonade Stand Tycoon',
+  description: 'Run a lemonade stand and learn business fundamentals.',
+  supplyOptions: [
+    { id: 'lemons', label: 'Fresh Lemons', quantity: 10, cost: 3, unit: 'bag' },
+    { id: 'sugar', label: 'Organic Sugar', quantity: 10, cost: 2, unit: 'bag' },
+    { id: 'cups', label: 'Compostable Cups', quantity: 20, cost: 1.5, unit: 'pack' }
+  ],
+  weatherPatterns: [
+    { id: 'sunny', emoji: '☀️', description: 'Perfect lemonade weather!', multiplier: 1.5 },
+    { id: 'hot', emoji: '🔥', description: 'Everyone wants cold drinks!', multiplier: 2 },
+    { id: 'cloudy', emoji: '☁️', description: 'Moderate demand expected', multiplier: 0.8 },
+    { id: 'rainy', emoji: '🌧️', description: 'Few customers today', multiplier: 0.3 }
+  ],
+  ingredientCosts: { lemons: 0.3, sugar: 0.2, cup: 0.075 },
+  demand: {
+    baseCustomers: { min: 20, max: 70 },
+    priceSensitivity: {
+      highPriceThreshold: 2,
+      highPriceMultiplier: 0.5,
+      lowPriceThreshold: 1,
+      lowPriceMultiplier: 1.2
+    },
+    recipeQualityRange: { min: 0.3, max: 1.5 }
+  },
+  recipeGuidance: {
+    minimumStrength: 2,
+    maximumStrength: 5,
+    minimumPrice: 0.5,
+    maximumPrice: 3
+  },
+  initialState: {
+    cash: 50,
+    day: 1,
+    revenue: 0,
+    expenses: 0,
+    inventory: { lemons: 0, sugar: 0, cups: 0 },
+    recipe: { lemons: 2, sugar: 1, price: 1 },
+    weather: 'sunny',
+    customerSatisfaction: 100,
+    isSellingActive: false,
+    dailySales: { cupsSold: 0, dailyRevenue: 0, dailyExpenses: 0 },
+    gameStatus: 'playing'
+  }
+}
+
+const buildActivity = (overrides: Partial<LemonadeStandActivityProps> = {}): LemonadeStandActivity => {
+  const mergedInitialState = {
+    ...defaultLemonadeProps.initialState,
+    ...(overrides.initialState ?? {}),
+    inventory: {
+      ...defaultLemonadeProps.initialState.inventory,
+      ...(overrides.initialState?.inventory ?? {})
+    },
+    recipe: {
+      ...defaultLemonadeProps.initialState.recipe,
+      ...(overrides.initialState?.recipe ?? {})
+    },
+    dailySales: {
+      ...defaultLemonadeProps.initialState.dailySales,
+      ...(overrides.initialState?.dailySales ?? {})
+    }
+  } satisfies LemonadeStandActivityProps['initialState']
+
+  const props: LemonadeStandActivityProps = {
+    ...defaultLemonadeProps,
+    ...overrides,
+    supplyOptions: overrides.supplyOptions ?? defaultLemonadeProps.supplyOptions,
+    weatherPatterns: overrides.weatherPatterns ?? defaultLemonadeProps.weatherPatterns,
+    ingredientCosts: overrides.ingredientCosts ?? defaultLemonadeProps.ingredientCosts,
+    demand: overrides.demand ?? defaultLemonadeProps.demand,
+    recipeGuidance: overrides.recipeGuidance ?? defaultLemonadeProps.recipeGuidance,
+    initialState: mergedInitialState
+  }
+
+  return {
+    id: 'activity-lemonade',
+    componentKey: 'lemonade-stand',
+    displayName: 'Lemonade Stand',
+    description: 'Simulated lemonade business.',
+    props,
+    gradingConfig: null,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+}
+
+describe('LemonadeStand', () => {
+  it('renders custom title and restores persisted state', async () => {
+    const activity = buildActivity({
+      title: 'Custom Lemonade Simulation'
+    })
+
+    const initialState: Partial<LemonadeStandState> = {
+      cash: 123,
+      day: 5
+    }
+
+    render(<LemonadeStand activity={activity} initialState={initialState} />)
+
+    expect(await screen.findByText('Custom Lemonade Simulation')).toBeInTheDocument()
+    expect(screen.getByText('$123.00')).toBeInTheDocument()
+    const dayLabel = screen.getByText('Day')
+    expect(dayLabel.parentElement).toHaveTextContent('5')
+  })
+
+  it('calls onStateChange when supplies are purchased', async () => {
+    const onStateChange = vi.fn()
+    const activity = buildActivity({
+      supplyOptions: [
+        { id: 'lemons', label: 'Fresh Lemons', quantity: 5, cost: 2, unit: 'bag' },
+        { id: 'sugar', label: 'Sugar', quantity: 5, cost: 2, unit: 'bag' },
+        { id: 'cups', label: 'Cups', quantity: 10, cost: 1, unit: 'pack' }
+      ],
+      initialState: {
+        cash: 10,
+        inventory: { lemons: 0, sugar: 0, cups: 0 }
+      }
+    })
+
+    render(<LemonadeStand activity={activity} onStateChange={onStateChange} />)
+
+    await waitFor(() => expect(onStateChange).toHaveBeenCalled())
+
+    const buyButtons = screen.getAllByRole('button', { name: /buy/i })
+    await userEvent.click(buyButtons[0])
+
+    await waitFor(() => expect(screen.getByText('$8.00')).toBeInTheDocument())
+    expect(onStateChange.mock.calls.at(-1)?.[0].cash).toBeCloseTo(8)
+  })
+})

--- a/components/business-simulations/LemonadeStand.tsx
+++ b/components/business-simulations/LemonadeStand.tsx
@@ -1,0 +1,891 @@
+/**
+ * LemonadeStand Component
+ * 
+ * DEVELOPER USAGE:
+ * ================
+ * Import and use this component in any React page or component:
+ * 
+ * ```tsx
+ * import { LemonadeStand } from '@/components/business-simulations/LemonadeStand'
+ * 
+ * export default function MyPage() {
+ *   return (
+ *     <div>
+ *       <LemonadeStand />
+ *     </div>
+ *   )
+ * }
+ * ```
+ * 
+ * The component is fully self-contained with its own state management.
+ * No props are required - it initializes with default values.
+ * 
+ * STUDENT INTERACTION & LEARNING OBJECTIVES:
+ * ==========================================
+ * 
+ * OBJECTIVE: Students learn fundamental business concepts through running
+ * a lemonade stand: profit/loss, pricing strategy, inventory management,
+ * customer satisfaction, and external factors (weather) affecting business.
+ * 
+ * HOW STUDENTS INTERACT:
+ * 1. **Monitor Business Dashboard**: Students see current cash ($50 starting),
+ *    day counter, total revenue, and profit/loss calculations.
+ * 
+ * 2. **Purchase Supplies**: Students buy ingredients with different costs:
+ *    - LEMONS: $3.00 for 10 lemons (bag)
+ *    - SUGAR: $2.00 for 10 units (bag) 
+ *    - CUPS: $1.50 for 20 cups (pack)
+ * 
+ * 3. **Manage Inventory**: Track remaining supplies:
+ *    - Monitor current stock levels of lemons, sugar, and cups
+ *    - Calculate maximum lemonade cups possible from current inventory
+ *    - Balance purchasing decisions with cash flow
+ * 
+ * 4. **Create Recipe & Set Pricing**:
+ *    - Adjust lemons per cup (1-5, affects taste and cost)
+ *    - Adjust sugar per cup (0-3, affects taste and cost)
+ *    - Set selling price per cup ($0.25-$5.00)
+ *    - Receive real-time feedback on recipe quality and pricing strategy
+ * 
+ * 5. **React to Weather Conditions**: 
+ *    - Weather changes daily and affects customer demand:
+ *      * ☀️ Sunny: +50% demand boost
+ *      * 🔥 Hot: +100% demand boost  
+ *      * ☁️ Cloudy: -20% demand reduction
+ *      * 🌧️ Rainy: -70% demand reduction
+ * 
+ * 6. **Daily Sales Simulation**: Click "Start Selling!" to begin:
+ *    - Animated sales progress bar shows customers buying
+ *    - Real-time updates of cups sold and revenue earned
+ *    - Must have sufficient supplies to make lemonade
+ * 
+ * 7. **Daily Business Reports**: After each sales day:
+ *    - Cups sold vs potential demand
+ *    - Total revenue for the day
+ *    - Cost of goods sold (ingredient costs per cup)
+ *    - Daily profit/loss calculation
+ *    - Customer satisfaction feedback
+ * 
+ * 8. **Strategic Optimization**: Students learn to:
+ *    - Balance ingredient costs with selling price for profit
+ *    - Adjust pricing based on weather forecasts
+ *    - Manage cash flow between purchasing and sales
+ *    - Optimize recipe for customer satisfaction vs cost
+ * 
+ * KEY LEARNING OUTCOMES:
+ * - Understanding revenue vs profit concepts
+ * - Price elasticity and demand sensitivity
+ * - Cost of Goods Sold (COGS) calculations
+ * - Inventory management and cash flow
+ * - External factors affecting business (weather = market conditions)
+ * - Customer satisfaction and repeat business
+ * - Strategic decision-making in uncertain conditions
+ * - Basic financial statements: revenue, expenses, profit
+ */
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { Separator } from '@/components/ui/separator'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { 
+  DollarSign, 
+  Calendar, 
+  TrendingUp,
+  ShoppingCart,
+  Package,
+  Coffee,
+  RefreshCw,
+  HelpCircle,
+  ChevronDown,
+  ChevronUp,
+  Play,
+  BarChart3,
+  Users,
+  Smile,
+  Frown
+} from 'lucide-react'
+
+import type { Activity } from '@/lib/db/schema/validators'
+import type { LemonadeStandActivityProps } from '@/lib/db/schema/activities'
+
+export type LemonadeStandActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'lemonade-stand'
+  props: LemonadeStandActivityProps
+}
+
+export interface LemonadeStandState {
+  cash: number
+  day: number
+  revenue: number
+  expenses: number
+  inventory: {
+    lemons: number
+    sugar: number
+    cups: number
+  }
+  recipe: {
+    lemons: number
+    sugar: number
+    price: number
+  }
+  weather: string
+  customerSatisfaction: number
+  isSellingActive: boolean
+  dailySales: {
+    cupsSold: number
+    dailyRevenue: number
+    dailyExpenses: number
+  }
+  gameStatus: 'playing' | 'ended'
+}
+
+interface LemonadeStandProps {
+  activity: LemonadeStandActivity
+  initialState?: Partial<LemonadeStandState>
+  onStateChange?: (state: LemonadeStandState) => void
+}
+
+type SupplyId = LemonadeStandActivityProps['supplyOptions'][number]['id']
+
+const cloneStateFromConfig = (state: LemonadeStandActivityProps['initialState']): LemonadeStandState => ({
+  ...state,
+  inventory: { ...state.inventory },
+  recipe: { ...state.recipe },
+  dailySales: { ...state.dailySales }
+})
+
+const mergeState = (base: LemonadeStandState, override?: Partial<LemonadeStandState>): LemonadeStandState => {
+  if (!override) {
+    return { ...base, inventory: { ...base.inventory }, recipe: { ...base.recipe }, dailySales: { ...base.dailySales } }
+  }
+
+  return {
+    cash: override.cash ?? base.cash,
+    day: override.day ?? base.day,
+    revenue: override.revenue ?? base.revenue,
+    expenses: override.expenses ?? base.expenses,
+    inventory: {
+      lemons: override.inventory?.lemons ?? base.inventory.lemons,
+      sugar: override.inventory?.sugar ?? base.inventory.sugar,
+      cups: override.inventory?.cups ?? base.inventory.cups
+    },
+    recipe: {
+      lemons: override.recipe?.lemons ?? base.recipe.lemons,
+      sugar: override.recipe?.sugar ?? base.recipe.sugar,
+      price: override.recipe?.price ?? base.recipe.price
+    },
+    weather: override.weather ?? base.weather,
+    customerSatisfaction: override.customerSatisfaction ?? base.customerSatisfaction,
+    isSellingActive: override.isSellingActive ?? base.isSellingActive,
+    dailySales: {
+      cupsSold: override.dailySales?.cupsSold ?? base.dailySales.cupsSold,
+      dailyRevenue: override.dailySales?.dailyRevenue ?? base.dailySales.dailyRevenue,
+      dailyExpenses: override.dailySales?.dailyExpenses ?? base.dailySales.dailyExpenses
+    },
+    gameStatus: override.gameStatus ?? base.gameStatus
+  }
+}
+
+export function LemonadeStand({ activity, initialState, onStateChange }: LemonadeStandProps) {
+  const baseState = useMemo(() => cloneStateFromConfig(activity.props.initialState), [activity.props.initialState])
+  const [gameState, setGameState] = useState<LemonadeStandState>(() => mergeState(baseState, initialState))
+  const [showInstructions, setShowInstructions] = useState(false)
+  const [notifications, setNotifications] = useState<Array<{
+    id: string
+    message: string
+    type: 'success' | 'warning' | 'error' | 'info'
+  }>>([])
+  const [salesProgress, setSalesProgress] = useState(0)
+  const salesIntervalRef = useRef<NodeJS.Timeout | null>(null)
+
+  const heroDescription = activity.description ?? activity.props.description
+  const supplyOptions = activity.props.supplyOptions
+  const supplyLookup = useMemo(
+    () => Object.fromEntries(supplyOptions.map((option) => [option.id, option])),
+    [supplyOptions]
+  )
+  const weatherPatterns = activity.props.weatherPatterns
+  const weatherLookup = useMemo(
+    () => Object.fromEntries(weatherPatterns.map((pattern) => [pattern.id, pattern])),
+    [weatherPatterns]
+  )
+  const ingredientCosts = activity.props.ingredientCosts
+  const demandConfig = activity.props.demand
+  const recipeGuidance = activity.props.recipeGuidance
+
+  useEffect(() => {
+    setGameState(mergeState(baseState, initialState))
+    setSalesProgress(0)
+    setNotifications([])
+    if (salesIntervalRef.current) {
+      clearInterval(salesIntervalRef.current)
+      salesIntervalRef.current = null
+    }
+  }, [baseState, initialState])
+
+  useEffect(() => {
+    return () => {
+      if (salesIntervalRef.current) {
+        clearInterval(salesIntervalRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    onStateChange?.(gameState)
+  }, [gameState, onStateChange])
+
+  const addNotification = useCallback((message: string, type: 'success' | 'warning' | 'error' | 'info') => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    setNotifications(prev => [...prev, { id, message, type }])
+    setTimeout(() => {
+      setNotifications(prev => prev.filter(n => n.id !== id))
+    }, 4000)
+  }, [])
+
+  const buySupply = useCallback((supplyId: SupplyId) => {
+    const config = supplyLookup[supplyId]
+    if (!config) {
+      return
+    }
+
+    if (gameState.cash < config.cost) {
+      addNotification(`Not enough cash! Need $${config.cost.toFixed(2)}`, 'error')
+      return
+    }
+
+    setGameState(prev => ({
+      ...prev,
+      cash: prev.cash - config.cost,
+      expenses: prev.expenses + config.cost,
+      inventory: {
+        ...prev.inventory,
+        [supplyId]: prev.inventory[supplyId] + config.quantity
+      }
+    }))
+
+    addNotification(`Bought ${config.quantity} ${config.label} for $${config.cost.toFixed(2)}`, 'success')
+  }, [gameState.cash, supplyLookup, addNotification])
+
+  const updateRecipe = useCallback((field: keyof LemonadeStandState['recipe'], value: number) => {
+    setGameState(prev => ({
+      ...prev,
+      recipe: {
+        ...prev.recipe,
+        [field]: value
+      }
+    }))
+  }, [])
+
+  const getRecipeFeedback = useCallback(() => {
+    const { lemons, sugar, price } = gameState.recipe
+    const totalIngredients = lemons + sugar
+
+    if (totalIngredients < recipeGuidance.minimumStrength) {
+      return { message: "Recipe too weak - customers won't like it!", color: 'text-red-600', icon: <Frown className="w-4 h-4" /> }
+    } else if (totalIngredients > recipeGuidance.maximumStrength) {
+      return { message: "Recipe too strong - too expensive to make!", color: 'text-red-600', icon: <Frown className="w-4 h-4" /> }
+    } else if (price < recipeGuidance.minimumPrice) {
+      return { message: "Price too low - you won't make profit!", color: 'text-red-600', icon: <Frown className="w-4 h-4" /> }
+    } else if (price > recipeGuidance.maximumPrice) {
+      return { message: "Price too high - customers won't buy!", color: 'text-red-600', icon: <Frown className="w-4 h-4" /> }
+    } else {
+      return { message: "Great recipe and pricing!", color: 'text-green-600', icon: <Smile className="w-4 h-4" /> }
+    }
+  }, [gameState.recipe, recipeGuidance])
+
+  const getMaxCupsFromInventory = useCallback(() => {
+    const { lemons, sugar, cups } = gameState.inventory
+    const { lemons: lemonsPerCup, sugar: sugarPerCup } = gameState.recipe
+    
+    return Math.min(
+      cups,
+      Math.floor(lemons / lemonsPerCup),
+      sugarPerCup > 0 ? Math.floor(sugar / sugarPerCup) : cups
+    )
+  }, [gameState.inventory, gameState.recipe])
+
+  const generateRandomWeather = useCallback(() => {
+    if (weatherPatterns.length === 0) {
+      return gameState.weather
+    }
+    const index = Math.floor(Math.random() * weatherPatterns.length)
+    return weatherPatterns[index]?.id ?? gameState.weather
+  }, [weatherPatterns, gameState.weather])
+
+  const completeSales = useCallback((cupsSold: number) => {
+    const dailyRevenue = cupsSold * gameState.recipe.price
+    const ingredientCost =
+      cupsSold *
+      (gameState.recipe.lemons * ingredientCosts.lemons +
+        gameState.recipe.sugar * ingredientCosts.sugar +
+        ingredientCosts.cup)
+
+    setGameState(prev => ({
+      ...prev,
+      revenue: prev.revenue + dailyRevenue,
+      inventory: {
+        lemons: prev.inventory.lemons - cupsSold * prev.recipe.lemons,
+        sugar: prev.inventory.sugar - cupsSold * prev.recipe.sugar,
+        cups: prev.inventory.cups - cupsSold
+      },
+      dailySales: {
+        cupsSold,
+        dailyRevenue,
+        dailyExpenses: ingredientCost
+      },
+      isSellingActive: false
+    }))
+
+    if (cupsSold > 30) {
+      addNotification('🎉 Amazing sales day! Customers loved your lemonade!', 'success')
+    } else if (cupsSold > 15) {
+      addNotification('👍 Good sales! Customers were satisfied.', 'success')
+    } else {
+      addNotification('😕 Slow sales day. Try adjusting your recipe or pricing.', 'warning')
+    }
+
+    addNotification(`Sold ${cupsSold} cups for $${dailyRevenue.toFixed(2)}!`, 'success')
+  }, [addNotification, gameState.recipe, ingredientCosts])
+
+  const simulateSales = useCallback(() => {
+    const maxCups = getMaxCupsFromInventory()
+    if (maxCups <= 0) {
+      addNotification('Not enough supplies to make lemonade!', 'error')
+      return
+    }
+
+    const newWeather = generateRandomWeather()
+
+    setGameState(prev => ({ ...prev, weather: newWeather, isSellingActive: true }))
+    setSalesProgress(0)
+
+    const weatherEffect = weatherLookup[newWeather] ?? { multiplier: 1, emoji: '⛅', description: 'Normal demand' }
+    let demandMultiplier = weatherEffect.multiplier
+
+    if (gameState.recipe.price > demandConfig.priceSensitivity.highPriceThreshold) {
+      demandMultiplier *= demandConfig.priceSensitivity.highPriceMultiplier
+    }
+    if (gameState.recipe.price < demandConfig.priceSensitivity.lowPriceThreshold) {
+      demandMultiplier *= demandConfig.priceSensitivity.lowPriceMultiplier
+    }
+
+    const recipeQuality = (gameState.recipe.lemons + gameState.recipe.sugar) / 4
+    demandMultiplier *= Math.max(
+      demandConfig.recipeQualityRange.min,
+      Math.min(demandConfig.recipeQualityRange.max, recipeQuality)
+    )
+
+    const customerRange = Math.max(0, demandConfig.baseCustomers.max - demandConfig.baseCustomers.min)
+    const potentialCustomers = Math.floor(Math.random() * (customerRange || 1) + demandConfig.baseCustomers.min)
+    const actualCustomers = Math.min(maxCups, Math.floor(potentialCustomers * demandMultiplier))
+
+    addNotification(`${weatherEffect.emoji} ${weatherEffect.description}`, 'info')
+
+    if (salesIntervalRef.current) {
+      clearInterval(salesIntervalRef.current)
+    }
+
+    let progress = 0
+    salesIntervalRef.current = setInterval(() => {
+      progress += Math.random() * 15 + 5
+      setSalesProgress(Math.min(100, progress))
+
+      if (progress >= 100) {
+        if (salesIntervalRef.current) {
+          clearInterval(salesIntervalRef.current)
+        }
+        completeSales(actualCustomers)
+      }
+    }, 300)
+  }, [
+    addNotification,
+    demandConfig,
+    gameState.recipe,
+    generateRandomWeather,
+    getMaxCupsFromInventory,
+    weatherLookup,
+    completeSales
+  ])
+
+  const endDay = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      day: prev.day + 1,
+      dailySales: { cupsSold: 0, dailyRevenue: 0, dailyExpenses: 0 }
+    }))
+    setSalesProgress(0)
+  }, [])
+
+  const resetGame = useCallback(() => {
+    setGameState(cloneStateFromConfig(activity.props.initialState))
+    setSalesProgress(0)
+    setNotifications([])
+    addNotification('Game reset successfully!', 'info')
+  }, [activity.props.initialState, addNotification])
+
+  const profit = gameState.revenue - gameState.expenses
+  const recipeFeedback = getRecipeFeedback()
+  const maxCups = getMaxCupsFromInventory()
+  const weatherInfo = weatherLookup[gameState.weather] ?? { emoji: '⛅', description: 'Normal demand', multiplier: 1 }
+  const costPerCup =
+    gameState.recipe.lemons * ingredientCosts.lemons +
+    gameState.recipe.sugar * ingredientCosts.sugar +
+    ingredientCosts.cup
+  const profitPerCup = gameState.recipe.price - costPerCup
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      {/* Header */}
+      <Card className="bg-gradient-to-r from-yellow-50 to-orange-50 border-yellow-200">
+        <CardHeader className="text-center">
+          <CardTitle className="text-3xl flex items-center justify-center gap-2">
+            {activity.props.title}
+          </CardTitle>
+          <CardDescription className="text-lg">
+            {heroDescription}
+          </CardDescription>
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowInstructions(!showInstructions)}
+              className="flex items-center gap-2"
+            >
+              <HelpCircle className="w-4 h-4" />
+              How to Play
+              {showInstructions ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Instructions Panel */}
+      {showInstructions && (
+        <Card className="border-yellow-200 bg-yellow-50">
+          <CardHeader>
+            <CardTitle className="text-xl text-yellow-800 flex items-center gap-2">
+              <HelpCircle className="w-5 h-5" />
+              {`How to Play ${activity.props.title}`}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Objective */}
+            <div>
+              <h4 className="font-semibold text-yellow-800 mb-2">🎯 Objective</h4>
+              <p className="text-yellow-700">
+                Run a profitable lemonade stand by managing inventory, creating the perfect recipe, 
+                setting optimal prices, and adapting to changing weather conditions!
+              </p>
+            </div>
+
+            {/* Game Flow */}
+            <div>
+              <h4 className="font-semibold text-yellow-800 mb-3">🔄 Game Flow</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <h5 className="font-medium text-yellow-700">1. Purchase Supplies:</h5>
+                  <ul className="text-sm text-yellow-600 space-y-1">
+                    {supplyOptions.map((option) => (
+                      <li key={option.id}>
+                        • {option.label}: ${option.cost.toFixed(2)} for {option.quantity} {option.unit}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="space-y-2">
+                  <h5 className="font-medium text-yellow-700">2. Create Recipe:</h5>
+                  <ul className="text-sm text-yellow-600 space-y-1">
+                    <li>• Adjust lemons per cup (1-5)</li>
+                    <li>• Adjust sugar per cup (0-3)</li>
+                    <li>• Set selling price ($0.25-$5.00)</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Weather Effects */}
+            <div>
+              <h4 className="font-semibold text-yellow-800 mb-3">🌤️ Weather Impact</h4>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                {weatherPatterns.map((pattern) => (
+                  <div key={pattern.id} className="p-2 bg-white rounded border text-center text-xs">
+                    <div className="text-lg mb-1">{pattern.emoji}</div>
+                    <div className="font-medium capitalize">{pattern.id}</div>
+                    <div className="text-gray-600">
+                      {pattern.multiplier > 1 ? '+' : ''}
+                      {((pattern.multiplier - 1) * 100).toFixed(0)}%
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Strategy Tips */}
+            <div>
+              <h4 className="font-semibold text-yellow-800 mb-2">💡 Success Tips</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+                  <h5 className="font-medium text-green-800 mb-1">Recipe Balance</h5>
+                  <ul className="text-xs text-green-700 space-y-1">
+                    <li>• Too few ingredients = weak taste</li>
+                    <li>• Too many ingredients = high costs</li>
+                    <li>• Sweet spot: 2-4 total ingredients</li>
+                  </ul>
+                </div>
+                <div className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+                  <h5 className="font-medium text-blue-800 mb-1">Pricing Strategy</h5>
+                  <ul className="text-xs text-blue-700 space-y-1">
+                    <li>• Consider weather for pricing</li>
+                    <li>• High prices = fewer customers</li>
+                    <li>• Low prices = less profit per cup</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Game Dashboard */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="bg-gradient-to-br from-green-50 to-green-100 border-green-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <DollarSign className="w-6 h-6 text-green-600" />
+            </div>
+            <p className="text-sm text-green-700 font-medium">Cash</p>
+            <p className={`text-2xl font-bold ${gameState.cash >= 0 ? 'text-green-800' : 'text-red-800'}`}>
+              ${gameState.cash.toFixed(2)}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <Calendar className="w-6 h-6 text-blue-600" />
+            </div>
+            <p className="text-sm text-blue-700 font-medium">Day</p>
+            <p className="text-2xl font-bold text-blue-800">{gameState.day}</p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-purple-50 to-purple-100 border-purple-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <TrendingUp className="w-6 h-6 text-purple-600" />
+            </div>
+            <p className="text-sm text-purple-700 font-medium">Total Revenue</p>
+            <p className="text-2xl font-bold text-purple-800">
+              ${gameState.revenue.toFixed(2)}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-orange-50 to-orange-100 border-orange-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <BarChart3 className="w-6 h-6 text-orange-600" />
+            </div>
+            <p className="text-sm text-orange-700 font-medium">Profit</p>
+            <p className={`text-2xl font-bold ${profit >= 0 ? 'text-orange-800' : 'text-red-800'}`}>
+              ${profit.toFixed(2)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Weather Display */}
+      <Card className="bg-gradient-to-r from-sky-50 to-blue-50 border-sky-200">
+        <CardContent className="p-4">
+          <div className="flex items-center justify-center gap-4">
+            <div className="text-4xl">{weatherInfo.emoji}</div>
+            <div>
+              <h3 className="text-lg font-semibold text-sky-800 capitalize">
+                Today&apos;s Weather: {gameState.weather}
+              </h3>
+              <p className="text-sky-600">{weatherInfo.description}</p>
+              <p className="text-sm text-sky-500">
+                Customer demand: {weatherInfo.multiplier > 1 ? '+' : ''}{((weatherInfo.multiplier - 1) * 100).toFixed(0)}%
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Supply Shopping */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShoppingCart className="w-5 h-5" />
+              Buy Supplies
+            </CardTitle>
+            <CardDescription>Purchase ingredients for your lemonade</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {supplyOptions.map((option) => (
+              <div key={option.id} className="flex items-center justify-between p-3 border rounded-lg">
+                <div>
+                  <div className="font-medium">{option.label} ({option.unit})</div>
+                  <div className="text-sm text-gray-600">
+                    {option.quantity} units - ${option.cost.toFixed(2)}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => buySupply(option.id)}
+                  disabled={gameState.cash < option.cost}
+                >
+                  Buy
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        {/* Inventory */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Package className="w-5 h-5" />
+              Inventory
+            </CardTitle>
+            <CardDescription>Current supplies in stock</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center p-3 bg-yellow-50 rounded-lg">
+                <div className="text-2xl mb-1">🍋</div>
+                <div className="font-semibold">{gameState.inventory.lemons}</div>
+                <div className="text-xs text-gray-600">Lemons</div>
+              </div>
+              <div className="text-center p-3 bg-white rounded-lg border">
+                <div className="text-2xl mb-1">🍬</div>
+                <div className="font-semibold">{gameState.inventory.sugar}</div>
+                <div className="text-xs text-gray-600">Sugar</div>
+              </div>
+              <div className="text-center p-3 bg-blue-50 rounded-lg">
+                <div className="text-2xl mb-1">🥤</div>
+                <div className="font-semibold">{gameState.inventory.cups}</div>
+                <div className="text-xs text-gray-600">Cups</div>
+              </div>
+            </div>
+            <div className="text-center p-2 bg-gray-50 rounded">
+              <div className="text-sm text-gray-600">Max cups possible:</div>
+              <div className="text-lg font-bold text-gray-800">{maxCups}</div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recipe & Pricing */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Coffee className="w-5 h-5" />
+            Recipe & Pricing
+          </CardTitle>
+          <CardDescription>Adjust your lemonade recipe and set the selling price</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="space-y-2">
+              <Label htmlFor="lemons">Lemons per cup</Label>
+              <Input
+                id="lemons"
+                type="number"
+                min="1"
+                max="5"
+                value={gameState.recipe.lemons}
+                onChange={(e) => updateRecipe('lemons', parseInt(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sugar">Sugar per cup</Label>
+              <Input
+                id="sugar"
+                type="number"
+                min="0"
+                max="3"
+                value={gameState.recipe.sugar}
+                onChange={(e) => updateRecipe('sugar', parseInt(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="price">Price per cup ($)</Label>
+              <Input
+                id="price"
+                type="number"
+                min="0.25"
+                max="5.00"
+                step="0.25"
+                value={gameState.recipe.price}
+                onChange={(e) => updateRecipe('price', parseFloat(e.target.value))}
+              />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-3">
+              <h4 className="font-medium">Recipe Feedback</h4>
+              <div className={`flex items-center gap-2 ${recipeFeedback.color}`}>
+                {recipeFeedback.icon}
+                <span className="text-sm">{recipeFeedback.message}</span>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <h4 className="font-medium">Cost Analysis</h4>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                <div>
+                  <span className="text-gray-600">Cost per cup:</span>
+                  <span className="ml-2 font-semibold text-red-600">
+                    ${costPerCup.toFixed(2)}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-600">Profit per cup:</span>
+                  <span className={`ml-2 font-semibold ${profitPerCup >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    ${profitPerCup.toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Sales Section */}
+      {gameState.isSellingActive && (
+        <Card className="border-blue-200 bg-blue-50">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="w-5 h-5" />
+              Selling Lemonade
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <Progress value={salesProgress} className="h-4" />
+              <div className="text-center">
+                <div className="text-sm text-blue-600">Sales in progress...</div>
+                <div className="text-xs text-blue-500">
+                  Customers are trying your lemonade!
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Daily Report */}
+      {gameState.dailySales.cupsSold > 0 && (
+        <Card className="border-green-200 bg-green-50">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <BarChart3 className="w-5 h-5" />
+              Daily Report
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-green-800">
+                  {gameState.dailySales.cupsSold}
+                </div>
+                <div className="text-sm text-green-600">Cups Sold</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-green-800">
+                  ${gameState.dailySales.dailyRevenue.toFixed(2)}
+                </div>
+                <div className="text-sm text-green-600">Revenue</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-red-600">
+                  ${gameState.dailySales.dailyExpenses.toFixed(2)}
+                </div>
+                <div className="text-sm text-red-600">Expenses</div>
+              </div>
+              <div className="text-center">
+                <div className={`text-2xl font-bold ${(gameState.dailySales.dailyRevenue - gameState.dailySales.dailyExpenses) >= 0 ? 'text-green-800' : 'text-red-800'}`}>
+                  ${(gameState.dailySales.dailyRevenue - gameState.dailySales.dailyExpenses).toFixed(2)}
+                </div>
+                <div className="text-sm text-gray-600">Daily Profit</div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Game Controls */}
+      <div className="flex justify-center gap-4">
+        <Button 
+          onClick={simulateSales}
+          size="lg"
+          className="bg-yellow-500 hover:bg-yellow-600"
+          disabled={gameState.isSellingActive || maxCups <= 0}
+        >
+          <Play className="w-4 h-4 mr-2" />
+          Start Selling!
+        </Button>
+        
+        {gameState.dailySales.cupsSold > 0 && (
+          <Button 
+            onClick={endDay}
+            size="lg"
+            variant="outline"
+          >
+            <Calendar className="w-4 h-4 mr-2" />
+            End Day
+          </Button>
+        )}
+        
+        <Button 
+          onClick={resetGame} 
+          variant="outline" 
+          size="lg"
+        >
+          <RefreshCw className="w-4 h-4 mr-2" />
+          Reset Game
+        </Button>
+      </div>
+
+      {/* Notifications */}
+      {notifications.length > 0 && (
+        <div className="fixed bottom-4 right-4 space-y-2 z-50">
+          {notifications.map((notification) => (
+            <Card key={notification.id} className={`
+              max-w-sm border-l-4 ${
+                notification.type === 'success' ? 'border-l-green-500 bg-green-50' :
+                notification.type === 'warning' ? 'border-l-yellow-500 bg-yellow-50' :
+                notification.type === 'error' ? 'border-l-red-500 bg-red-50' :
+                'border-l-blue-500 bg-blue-50'
+              }
+            `}>
+              <CardContent className="p-3">
+                <p className={`text-sm font-medium ${
+                  notification.type === 'success' ? 'text-green-800' :
+                  notification.type === 'warning' ? 'text-yellow-800' :
+                  notification.type === 'error' ? 'text-red-800' :
+                  'text-blue-800'
+                }`}>
+                  {notification.message}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+export default LemonadeStand

--- a/components/business-simulations/StartupJourney.test.tsx
+++ b/components/business-simulations/StartupJourney.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { StartupJourney, type StartupJourneyActivity, type StartupJourneyState } from './StartupJourney'
+import type { StartupJourneyActivityProps } from '@/lib/db/schema/activities'
+
+const defaultStartupProps: StartupJourneyActivityProps = {
+  title: 'Startup Journey',
+  description: 'Guide a startup from idea to success.',
+  stages: [
+    { id: 'idea', name: 'Idea', badgeClassName: 'bg-yellow-100 text-yellow-800 border-yellow-300', progress: 20, icon: 'lightbulb' },
+    { id: 'prototype', name: 'Prototype', badgeClassName: 'bg-blue-100 text-blue-800 border-blue-300', progress: 40, icon: 'code' },
+    { id: 'launch', name: 'Launch', badgeClassName: 'bg-purple-100 text-purple-800 border-purple-300', progress: 60, icon: 'rocket' },
+    { id: 'growth', name: 'Growth', badgeClassName: 'bg-green-100 text-green-800 border-green-300', progress: 80, icon: 'chart-line' },
+    { id: 'success', name: 'Success', badgeClassName: 'bg-amber-100 text-amber-800 border-amber-300', progress: 100, icon: 'crown' }
+  ],
+  decisions: [
+    {
+      id: 'initial-funding',
+      type: 'funding',
+      title: 'Initial Funding Strategy',
+      description: 'You have a great app idea! How will you fund development?',
+      options: [
+        {
+          id: 'bootstrap',
+          title: 'Bootstrap with Personal Savings',
+          description: 'Use $5,000 of your own money. Lower burn rate but limited resources.',
+          effects: { funding: 5000, burn: -500 }
+        },
+        {
+          id: 'accelerator',
+          title: 'Apply to Startup Accelerator',
+          description: 'Get $25,000 funding plus mentorship and network access.',
+          effects: { funding: 25000, users: 100, growth: 0.2 }
+        },
+        {
+          id: 'angel-investors',
+          title: 'Pitch to Angel Investors',
+          description: 'Raise $100,000 but higher pressure and burn rate.',
+          effects: { funding: 100000, burn: 6000 }
+        }
+      ]
+    }
+  ],
+  decisionFlow: [
+    { stageId: 'idea', decisionIds: ['initial-funding'] }
+  ],
+  winConditions: {
+    revenueTarget: 50000,
+    successRevenueTarget: 50000,
+    timeLimitMonths: 24,
+    timeLimitRevenueTarget: 20000,
+    successStageId: 'success'
+  },
+  initialState: {
+    stage: 'idea',
+    funding: 10000,
+    monthlyBurn: 2000,
+    users: 100,
+    revenue: 0,
+    month: 1,
+    maxMonths: 24,
+    decisions: [],
+    currentDecisionId: 'initial-funding',
+    userGrowthRate: 0.1,
+    revenuePerUser: 0,
+    gameStatus: 'playing'
+  }
+}
+
+const buildActivity = (overrides: Partial<StartupJourneyActivityProps> = {}): StartupJourneyActivity => {
+  const props: StartupJourneyActivityProps = {
+    ...defaultStartupProps,
+    ...overrides,
+    stages: overrides.stages ?? defaultStartupProps.stages,
+    decisions: overrides.decisions ?? defaultStartupProps.decisions,
+    decisionFlow: overrides.decisionFlow ?? defaultStartupProps.decisionFlow,
+    winConditions: overrides.winConditions ?? defaultStartupProps.winConditions,
+    initialState: {
+      ...defaultStartupProps.initialState,
+      ...(overrides.initialState ?? {})
+    }
+  }
+
+  return {
+    id: 'activity-startup',
+    componentKey: 'startup-journey',
+    displayName: 'Startup Journey',
+    description: 'Strategic startup simulation.',
+    props,
+    gradingConfig: null,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+}
+
+describe('StartupJourney', () => {
+  it('renders current stage and applies persisted state', async () => {
+    const activity = buildActivity()
+    const initialState: Partial<StartupJourneyState> = {
+      stage: 'growth',
+      funding: 50000,
+      month: 6
+    }
+
+    render(<StartupJourney activity={activity} initialState={initialState} />)
+
+    expect(await screen.findByText('Current Stage: Growth')).toBeInTheDocument()
+    expect(screen.getByText(/Month 6/)).toBeInTheDocument()
+    expect(screen.getByText('$50,000')).toBeInTheDocument()
+  })
+
+  it('updates funding and notifies parent when a decision is made', async () => {
+    const onStateChange = vi.fn()
+    const activity = buildActivity()
+
+    render(<StartupJourney activity={activity} onStateChange={onStateChange} />)
+
+    await waitFor(() => expect(onStateChange).toHaveBeenCalled())
+
+    await screen.findByRole('heading', { name: /Strategic Decision/i })
+    const optionButtons = await screen.findAllByRole('button', { name: /Choose This Option/i })
+    await userEvent.click(optionButtons[0])
+
+    await waitFor(() => expect(screen.getByText('$15,000')).toBeInTheDocument())
+    expect(onStateChange.mock.calls.at(-1)?.[0].funding).toBe(15000)
+  })
+})

--- a/components/business-simulations/StartupJourney.tsx
+++ b/components/business-simulations/StartupJourney.tsx
@@ -1,0 +1,745 @@
+/**
+ * StartupJourney Component
+ * 
+ * DEVELOPER USAGE:
+ * ================
+ * Import and use this component in any React page or component:
+ * 
+ * ```tsx
+ * import { StartupJourney } from '@/components/business-simulations/StartupJourney'
+ * 
+ * export default function MyPage() {
+ *   return (
+ *     <div>
+ *       <StartupJourney />
+ *     </div>
+ *   )
+ * }
+ * ```
+ * 
+ * The component is fully self-contained with its own state management.
+ * No props are required - it initializes with default values.
+ * 
+ * STUDENT INTERACTION & LEARNING OBJECTIVES:
+ * ==========================================
+ * 
+ * OBJECTIVE: Students experience the startup journey from idea to growth,
+ * learning about funding decisions, burn rates, user acquisition, and strategic choices.
+ * 
+ * HOW STUDENTS INTERACT:
+ * 1. **Monitor Startup Dashboard**: Students see current funding ($10,000 starting),
+ *    monthly burn rate ($2,000), user count (100), revenue ($0), and current stage.
+ * 
+ * 2. **Make Strategic Decisions**: At each stage, students face critical choices:
+ *    - FUNDING: Bootstrap vs Accelerator vs Angel investors
+ *    - TEAM: Hire developers vs marketers vs business development
+ *    - PRODUCT: Focus on features vs user feedback vs scaling
+ *    - GROWTH: Marketing spend vs organic growth vs partnerships
+ * 
+ * 3. **Progress Through Stages**: 
+ *    - IDEA: Initial concept and first funding decisions
+ *    - PROTOTYPE: Build MVP and validate market fit
+ *    - LAUNCH: Go to market and acquire first customers
+ *    - GROWTH: Scale operations and user base
+ *    - SUCCESS: Achieve profitability or exit opportunity
+ * 
+ * 4. **Manage Resources**: 
+ *    - Track funding runway (months remaining at current burn)
+ *    - Balance user growth with revenue generation
+ *    - Make decisions that affect burn rate and growth
+ * 
+ * 5. **Experience Consequences**: Each decision impacts:
+ *    - Monthly burn rate (operational costs)
+ *    - User growth rate and retention
+ *    - Revenue potential and monetization
+ *    - Available funding and runway
+ * 
+ * 6. **Learn from Outcomes**: 
+ *    - Successful decisions advance to next stage
+ *    - Poor choices may require course correction
+ *    - Random market events create additional challenges
+ * 
+ * KEY LEARNING OUTCOMES:
+ * - Understanding startup funding lifecycle and sources
+ * - Strategic decision-making under resource constraints
+ * - Balancing growth, profitability, and sustainability
+ * - Risk management and runway optimization
+ * - Market dynamics and competitive positioning
+ * - Performance metrics: CAC, LTV, burn rate, runway
+ */
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import {
+  type LucideIcon,
+  DollarSign, 
+  Calendar, 
+  TrendingUp,
+  Users,
+  Rocket,
+  Lightbulb,
+  Target,
+  ChartLine,
+  CheckCircle,
+  XCircle,
+  RefreshCw,
+  HelpCircle,
+  ChevronDown,
+  ChevronUp,
+  Building,
+  Code,
+  Megaphone,
+  Crown,
+  Zap
+} from 'lucide-react'
+
+import type { Activity } from '@/lib/db/schema/validators'
+import type { StartupJourneyActivityProps } from '@/lib/db/schema/activities'
+
+export type StartupJourneyActivity = Omit<Activity, 'componentKey' | 'props'> & {
+  componentKey: 'startup-journey'
+  props: StartupJourneyActivityProps
+}
+
+export interface StartupJourneyState {
+  stage: string
+  funding: number
+  monthlyBurn: number
+  users: number
+  revenue: number
+  month: number
+  maxMonths: number
+  decisions: string[]
+  currentDecisionId: string | null
+  userGrowthRate: number
+  revenuePerUser: number
+  gameStatus: 'playing' | 'won' | 'lost'
+}
+
+interface StartupJourneyProps {
+  activity: StartupJourneyActivity
+  initialState?: Partial<StartupJourneyState>
+  onStateChange?: (state: StartupJourneyState) => void
+}
+
+const STAGE_ICONS: Record<string, LucideIcon> = {
+  lightbulb: Lightbulb,
+  code: Code,
+  rocket: Rocket,
+  'chart-line': ChartLine,
+  crown: Crown,
+  megaphone: Megaphone,
+  building: Building,
+  target: Target,
+  zap: Zap
+}
+
+const cloneStateFromConfig = (state: StartupJourneyActivityProps['initialState']): StartupJourneyState => ({
+  ...state,
+  decisions: [...state.decisions],
+  currentDecisionId: state.currentDecisionId ?? null
+})
+
+const mergeStartupState = (base: StartupJourneyState, override?: Partial<StartupJourneyState>): StartupJourneyState => {
+  if (!override) {
+    return {
+      ...base,
+      decisions: [...base.decisions]
+    }
+  }
+
+  return {
+    stage: override.stage ?? base.stage,
+    funding: override.funding ?? base.funding,
+    monthlyBurn: override.monthlyBurn ?? base.monthlyBurn,
+    users: override.users ?? base.users,
+    revenue: override.revenue ?? base.revenue,
+    month: override.month ?? base.month,
+    maxMonths: override.maxMonths ?? base.maxMonths,
+    decisions: override.decisions ? [...override.decisions] : [...base.decisions],
+    currentDecisionId: override.currentDecisionId ?? base.currentDecisionId,
+    userGrowthRate: override.userGrowthRate ?? base.userGrowthRate,
+    revenuePerUser: override.revenuePerUser ?? base.revenuePerUser,
+    gameStatus: override.gameStatus ?? base.gameStatus
+  }
+}
+
+export function StartupJourney({ activity, initialState, onStateChange }: StartupJourneyProps) {
+  const baseState = useMemo(() => cloneStateFromConfig(activity.props.initialState), [activity.props.initialState])
+  const [gameState, setGameState] = useState<StartupJourneyState>(() => mergeStartupState(baseState, initialState))
+  const [notifications, setNotifications] = useState<Array<{
+    id: string
+    message: string
+    type: 'success' | 'warning' | 'error' | 'info'
+  }>>([])
+  const [showInstructions, setShowInstructions] = useState(false)
+  const stageOrder = useMemo(() => activity.props.stages.map((stage) => stage.id), [activity.props.stages])
+  const stageMap = useMemo(() => new Map(activity.props.stages.map((stage) => [stage.id, stage])), [activity.props.stages])
+  const decisionMap = useMemo(() => new Map(activity.props.decisions.map((decision) => [decision.id, decision])), [activity.props.decisions])
+  const decisionFlowMap = useMemo(
+    () => new Map(activity.props.decisionFlow.map((flow) => [flow.stageId, flow.decisionIds])),
+    [activity.props.decisionFlow]
+  )
+  const heroDescription = activity.description ?? activity.props.description
+  const winConditions = activity.props.winConditions
+
+  useEffect(() => {
+    setGameState(mergeStartupState(baseState, initialState))
+  }, [baseState, initialState])
+
+  useEffect(() => {
+    onStateChange?.(gameState)
+  }, [gameState, onStateChange])
+
+  const getStageBadgeClass = useCallback(
+    (stageId: string) => stageMap.get(stageId)?.badgeClassName ?? 'bg-slate-100 text-slate-800 border-slate-300',
+    [stageMap]
+  )
+
+  const advanceStage = useCallback(
+    (currentStage: string) => {
+      const index = stageOrder.indexOf(currentStage)
+      if (index >= 0 && index < stageOrder.length - 1) {
+        return stageOrder[index + 1]
+      }
+      return currentStage
+    },
+    [stageOrder]
+  )
+
+  const getNextDecisionId = useCallback(
+    (stageId: string, completed: string[]) => {
+      const flow = decisionFlowMap.get(stageId) ?? []
+      return flow.find((decisionId) => !completed.includes(decisionId)) ?? null
+    },
+    [decisionFlowMap]
+  )
+
+  const calculateRunway = useCallback(() => {
+    return gameState.monthlyBurn > 0 ? Math.floor(gameState.funding / gameState.monthlyBurn) : 999
+  }, [gameState.funding, gameState.monthlyBurn])
+
+  const currentDecision = gameState.currentDecisionId ? decisionMap.get(gameState.currentDecisionId) ?? null : null
+  const stageInfo = stageMap.get(gameState.stage)
+  const StageIconComponent = stageInfo ? STAGE_ICONS[stageInfo.icon] ?? Rocket : Rocket
+  const stageBadgeClass = getStageBadgeClass(gameState.stage)
+  const stageProgress = stageInfo?.progress ?? 0
+  const successStageName = stageMap.get(winConditions.successStageId)?.name ?? winConditions.successStageId
+
+  const addNotification = useCallback((message: string, type: 'success' | 'warning' | 'error' | 'info') => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    setNotifications(prev => [...prev, { id, message, type }])
+    setTimeout(() => {
+      setNotifications(prev => prev.filter(n => n.id !== id))
+    }, 5000)
+  }, [])
+
+  const makeDecision = useCallback(
+    (decisionId: string, optionId: string) => {
+      const decision = decisionMap.get(decisionId)
+      if (!decision) {
+        return
+      }
+
+      const option = decision.options.find((opt) => opt.id === optionId)
+      if (!option) {
+        return
+      }
+
+      setGameState((prev) => {
+        const newFunding = Math.max(0, prev.funding + (option.effects.funding ?? 0))
+        const newBurn = Math.max(1000, prev.monthlyBurn + (option.effects.burn ?? 0))
+        const newUsers = Math.max(0, prev.users + (option.effects.users ?? 0))
+        const newRevenue = Math.max(0, prev.revenue + (option.effects.revenue ?? 0))
+        const newGrowthRate = Math.max(0, prev.userGrowthRate + (option.effects.growth ?? 0))
+        const newRevenuePerUser = Math.max(0, prev.revenuePerUser + (option.effects.revenuePerUser ?? 0))
+        const updatedDecisions = prev.decisions.includes(decisionId) ? prev.decisions : [...prev.decisions, decisionId]
+
+        let nextStage = prev.stage
+        const stageFlow = decisionFlowMap.get(prev.stage) ?? []
+        const completedStage = stageFlow.length === 0 || stageFlow.every((id) => updatedDecisions.includes(id))
+        if (completedStage) {
+          nextStage = advanceStage(prev.stage)
+        }
+
+        const nextDecisionId = getNextDecisionId(nextStage, updatedDecisions)
+
+        return {
+          ...prev,
+          funding: newFunding,
+          monthlyBurn: newBurn,
+          users: newUsers,
+          revenue: newRevenue,
+          userGrowthRate: newGrowthRate,
+          revenuePerUser: newRevenuePerUser,
+          stage: nextStage,
+          decisions: updatedDecisions,
+          currentDecisionId: nextDecisionId
+        }
+      })
+
+      addNotification(`Decision made: ${option.title}`, 'success')
+
+      if (option.effects.funding) {
+        addNotification(
+          `Funding ${option.effects.funding > 0 ? 'increased' : 'decreased'} by $${Math.abs(option.effects.funding).toLocaleString()}`,
+          option.effects.funding > 0 ? 'success' : 'warning'
+        )
+      }
+      if (option.effects.users) {
+        addNotification(
+          `User base ${option.effects.users > 0 ? 'grew' : 'declined'} by ${Math.abs(option.effects.users)}`,
+          option.effects.users > 0 ? 'success' : 'warning'
+        )
+      }
+    },
+    [advanceStage, addNotification, decisionFlowMap, decisionMap, getNextDecisionId]
+  )
+
+  const advanceMonth = useCallback(() => {
+    if (gameState.gameStatus !== 'playing') return
+
+    setGameState((prev) => {
+      const newMonth = prev.month + 1
+      const userGrowth = Math.floor(prev.users * prev.userGrowthRate)
+      const newUsers = prev.users + userGrowth
+      const monthlyRevenue = Math.floor(newUsers * prev.revenuePerUser)
+      const newRevenue = prev.revenue + monthlyRevenue
+      const newFunding = Math.max(0, prev.funding - prev.monthlyBurn + monthlyRevenue)
+
+      let newGameStatus = prev.gameStatus
+      if (newFunding <= 0) {
+        newGameStatus = 'lost'
+        addNotification('Out of funding! Your startup has failed.', 'error')
+      } else if (prev.stage === winConditions.successStageId || newRevenue >= winConditions.successRevenueTarget) {
+        newGameStatus = 'won'
+        addNotification('Congratulations! Your startup is successful!', 'success')
+      } else {
+        const timeLimit = Math.min(prev.maxMonths, winConditions.timeLimitMonths)
+        if (newMonth >= timeLimit) {
+          if (newRevenue >= winConditions.timeLimitRevenueTarget) {
+            newGameStatus = 'won'
+            addNotification("Time's up! Your startup achieved sustainable revenue!", 'success')
+          } else {
+            newGameStatus = 'lost'
+            addNotification("Time's up! Your startup didn't achieve sufficient traction.", 'error')
+          }
+        }
+      }
+
+      if (userGrowth > 0) {
+        addNotification(`User base grew by ${userGrowth} users`, 'success')
+      }
+      if (monthlyRevenue > 0) {
+        addNotification(`Generated $${monthlyRevenue.toLocaleString()} in revenue`, 'success')
+      }
+      addNotification(`Monthly burn: $${prev.monthlyBurn.toLocaleString()}`, 'info')
+
+      return {
+        ...prev,
+        month: newMonth,
+        users: newUsers,
+        revenue: newRevenue,
+        funding: newFunding,
+        gameStatus: newGameStatus
+      }
+    })
+  }, [gameState.gameStatus, addNotification, winConditions])
+
+  const resetGame = useCallback(() => {
+    setGameState(cloneStateFromConfig(activity.props.initialState))
+    setNotifications([])
+    addNotification('Game reset successfully', 'info')
+  }, [activity.props.initialState, addNotification])
+
+  const runway = calculateRunway()
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      {/* Header */}
+      <Card className="bg-gradient-to-r from-purple-50 to-blue-50 border-purple-200">
+        <CardHeader className="text-center">
+          <CardTitle className="text-3xl flex items-center justify-center gap-2">
+            <Rocket className="w-8 h-8 text-purple-600" />
+            {activity.props.title}
+          </CardTitle>
+          <CardDescription className="text-lg">
+            {heroDescription}
+          </CardDescription>
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowInstructions(!showInstructions)}
+              className="flex items-center gap-2"
+            >
+              <HelpCircle className="w-4 h-4" />
+              How to Play
+              {showInstructions ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Instructions Panel */}
+      {showInstructions && (
+        <Card className="border-purple-200 bg-purple-50">
+          <CardHeader>
+            <CardTitle className="text-xl text-purple-800 flex items-center gap-2">
+              <HelpCircle className="w-5 h-5" />
+              {`How to Play ${activity.props.title}`}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Objective */}
+            <div>
+              <h4 className="font-semibold text-purple-800 mb-2">🎯 Objective</h4>
+              <p className="text-purple-700">
+                Build a successful tech startup over {winConditions.timeLimitMonths} months. Start with $
+                {activity.props.initialState.funding.toLocaleString()} in funding, make strategic decisions to grow your user base,
+                generate revenue, and manage your runway while progressing through each milestone.
+              </p>
+            </div>
+
+            {/* Startup Stages */}
+            <div>
+              <h4 className="font-semibold text-purple-800 mb-3">🚀 Startup Stages</h4>
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                {activity.props.stages.map((stage) => {
+                  const Icon = STAGE_ICONS[stage.icon] ?? Rocket
+                  return (
+                    <div key={stage.id} className="p-3 bg-white rounded-lg border text-center">
+                      <div className="flex items-center justify-center mb-2">
+                        <Icon className="w-5 h-5 text-purple-700" />
+                      </div>
+                      <h5 className="font-medium text-sm">{stage.name}</h5>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+
+            {/* Key Metrics */}
+            <div>
+              <h4 className="font-semibold text-purple-800 mb-3">📊 Key Metrics to Monitor</h4>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div className="p-3 bg-white rounded-lg border text-center">
+                  <div className="flex items-center justify-center mb-1">
+                    <DollarSign className="w-4 h-4 text-green-600" />
+                  </div>
+                  <h5 className="font-medium text-sm">Funding</h5>
+                  <p className="text-xs text-gray-600">Cash available</p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border text-center">
+                  <div className="flex items-center justify-center mb-1">
+                    <TrendingUp className="w-4 h-4 text-red-600" />
+                  </div>
+                  <h5 className="font-medium text-sm">Burn Rate</h5>
+                  <p className="text-xs text-gray-600">Monthly expenses</p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border text-center">
+                  <div className="flex items-center justify-center mb-1">
+                    <Users className="w-4 h-4 text-blue-600" />
+                  </div>
+                  <h5 className="font-medium text-sm">Users</h5>
+                  <p className="text-xs text-gray-600">Active user base</p>
+                </div>
+                <div className="p-3 bg-white rounded-lg border text-center">
+                  <div className="flex items-center justify-center mb-1">
+                    <Target className="w-4 h-4 text-purple-600" />
+                  </div>
+                  <h5 className="font-medium text-sm">Revenue</h5>
+                  <p className="text-xs text-gray-600">Total generated</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Decision Types */}
+            <div>
+              <h4 className="font-semibold text-purple-800 mb-3">🎯 Strategic Decision Areas</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <h5 className="font-medium text-purple-700">Funding Decisions:</h5>
+                  <ul className="text-sm text-purple-600 space-y-1">
+                    <li>• Bootstrap vs External investment</li>
+                    <li>• Accelerator programs vs Angel investors</li>
+                    <li>• Equity vs Debt financing</li>
+                  </ul>
+                </div>
+                <div className="space-y-2">
+                  <h5 className="font-medium text-purple-700">Growth Strategies:</h5>
+                  <ul className="text-sm text-purple-600 space-y-1">
+                    <li>• Team building and hiring priorities</li>
+                    <li>• Product development vs Marketing focus</li>
+                    <li>• Revenue models and monetization</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Success Conditions */}
+            <div>
+              <h4 className="font-semibold text-purple-800 mb-2">🏆 Success Conditions</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+                  <h5 className="font-medium text-green-800 mb-1">Victory Conditions</h5>
+                  <ul className="text-xs text-green-700 space-y-1">
+                    <li>• Reach &quot;{successStageName}&quot; stage</li>
+                    <li>• Generate ${winConditions.successRevenueTarget.toLocaleString()}+ in total revenue</li>
+                    <li>• Achieve ${winConditions.timeLimitRevenueTarget.toLocaleString()}+ revenue by month {winConditions.timeLimitMonths}</li>
+                    <li>• Maintain positive cash flow</li>
+                  </ul>
+                </div>
+                <div className="p-3 bg-red-50 rounded-lg border border-red-200">
+                  <h5 className="font-medium text-red-800 mb-1">Failure Conditions</h5>
+                  <ul className="text-xs text-red-700 space-y-1">
+                    <li>• Run out of funding (burn &gt; available cash)</li>
+                    <li>• Fail to reach ${winConditions.timeLimitRevenueTarget.toLocaleString()} by month {winConditions.timeLimitMonths}</li>
+                    <li>• Poor strategic decisions compound</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Game Status */}
+      {gameState.gameStatus !== 'playing' && (
+        <Card className={`border-2 ${gameState.gameStatus === 'won' ? 'border-green-500 bg-green-50' : 'border-red-500 bg-red-50'}`}>
+          <CardContent className="p-6 text-center">
+            <div className="flex items-center justify-center gap-2 mb-2">
+              {gameState.gameStatus === 'won' ? (
+                <CheckCircle className="w-8 h-8 text-green-600" />
+              ) : (
+                <XCircle className="w-8 h-8 text-red-600" />
+              )}
+              <h3 className={`text-2xl font-bold ${gameState.gameStatus === 'won' ? 'text-green-800' : 'text-red-800'}`}>
+                {gameState.gameStatus === 'won' ? 'Startup Success!' : 'Startup Failed'}
+              </h3>
+            </div>
+            <p className={`text-lg ${gameState.gameStatus === 'won' ? 'text-green-700' : 'text-red-700'}`}>
+              {gameState.gameStatus === 'won' 
+                ? `Congratulations! Your startup reached ${gameState.stage} stage with $${gameState.revenue.toLocaleString()} in revenue!`
+                : `Your startup journey ended at ${gameState.stage} stage. Better luck next time!`
+              }
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Startup Dashboard */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="bg-gradient-to-br from-green-50 to-green-100 border-green-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <DollarSign className="w-6 h-6 text-green-600" />
+            </div>
+            <p className="text-sm text-green-700 font-medium">Funding</p>
+            <p className={`text-2xl font-bold ${gameState.funding >= 0 ? 'text-green-800' : 'text-red-800'}`}>
+              ${gameState.funding.toLocaleString()}
+            </p>
+            <p className="text-xs text-green-600">
+              {runway} months runway
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-red-50 to-red-100 border-red-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <TrendingUp className="w-6 h-6 text-red-600" />
+            </div>
+            <p className="text-sm text-red-700 font-medium">Monthly Burn</p>
+            <p className="text-2xl font-bold text-red-800">
+              ${gameState.monthlyBurn.toLocaleString()}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <Users className="w-6 h-6 text-blue-600" />
+            </div>
+            <p className="text-sm text-blue-700 font-medium">Users</p>
+            <p className="text-2xl font-bold text-blue-800">
+              {gameState.users.toLocaleString()}
+            </p>
+            <p className="text-xs text-blue-600">
+              +{(gameState.userGrowthRate * 100).toFixed(0)}% monthly
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-br from-purple-50 to-purple-100 border-purple-200">
+          <CardContent className="p-4 text-center">
+            <div className="flex items-center justify-center mb-2">
+              <Target className="w-6 h-6 text-purple-600" />
+            </div>
+            <p className="text-sm text-purple-700 font-medium">Revenue</p>
+            <p className="text-2xl font-bold text-purple-800">
+              ${gameState.revenue.toLocaleString()}
+            </p>
+            <p className="text-xs text-purple-600">
+              ${gameState.revenuePerUser.toFixed(2)} per user
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Current Stage */}
+      <Card className="bg-gradient-to-r from-slate-50 to-slate-100">
+        <CardContent className="p-6">
+          <div className="text-center space-y-4">
+            <div className="flex items-center justify-center gap-3">
+              <div className="p-2 rounded-full bg-white shadow-sm">
+                <StageIconComponent className="w-6 h-6 text-purple-700" />
+              </div>
+              <h3 className="text-2xl font-bold text-slate-800">
+                Current Stage: {stageInfo?.name ?? gameState.stage}
+              </h3>
+              <Badge className={stageBadgeClass}>
+                Month {gameState.month}
+              </Badge>
+            </div>
+            
+            <div className="max-w-md mx-auto">
+              <div className="flex justify-between items-center mb-2">
+                <span className="text-sm font-medium text-slate-600">Progress</span>
+                <span className="text-sm text-slate-600">{stageProgress}%</span>
+              </div>
+              <Progress value={stageProgress} className="h-3" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Current Decision */}
+      {currentDecision && gameState.gameStatus === 'playing' && (
+        <Card className="border-2 border-blue-200 bg-blue-50">
+          <CardHeader>
+            <CardTitle role="heading" aria-level={3} className="text-xl text-blue-800 flex items-center gap-2">
+              <Zap className="w-5 h-5" />
+              Strategic Decision
+            </CardTitle>
+            <CardDescription className="text-blue-700">
+              {currentDecision.description}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <h4 className="font-semibold text-blue-800 mb-4">{currentDecision.title}</h4>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {currentDecision.options.map((option) => (
+                <Card key={option.id} className="cursor-pointer hover:shadow-md transition-shadow">
+                  <CardContent className="p-4">
+                    <h5 className="font-medium text-slate-800 mb-2">{option.title}</h5>
+                    <p className="text-sm text-slate-600 mb-4">{option.description}</p>
+                    
+                    {/* Effects Preview */}
+                    <div className="space-y-1 mb-4">
+                      {option.effects.funding && (
+                        <div className="flex items-center gap-2 text-xs">
+                          <DollarSign className="w-3 h-3" />
+                          <span className={option.effects.funding > 0 ? 'text-green-600' : 'text-red-600'}>
+                            {option.effects.funding > 0 ? '+' : ''}${option.effects.funding.toLocaleString()} funding
+                          </span>
+                        </div>
+                      )}
+                      {option.effects.burn && (
+                        <div className="flex items-center gap-2 text-xs">
+                          <TrendingUp className="w-3 h-3" />
+                          <span className={option.effects.burn > 0 ? 'text-red-600' : 'text-green-600'}>
+                            {option.effects.burn > 0 ? '+' : ''}${option.effects.burn.toLocaleString()} monthly burn
+                          </span>
+                        </div>
+                      )}
+                      {option.effects.users && (
+                        <div className="flex items-center gap-2 text-xs">
+                          <Users className="w-3 h-3" />
+                          <span className={option.effects.users > 0 ? 'text-blue-600' : 'text-red-600'}>
+                            {option.effects.users > 0 ? '+' : ''}{option.effects.users} users
+                          </span>
+                        </div>
+                      )}
+                      {option.effects.growth && (
+                        <div className="flex items-center gap-2 text-xs">
+                          <ChartLine className="w-3 h-3" />
+                          <span className="text-purple-600">
+                            {option.effects.growth > 0 ? '+' : ''}{(option.effects.growth * 100).toFixed(0)}% growth rate
+                          </span>
+                        </div>
+                      )}
+                    </div>
+
+                    <Button 
+                      className="w-full" 
+                      onClick={() => makeDecision(currentDecision.id, option.id)}
+                      variant="outline"
+                    >
+                      Choose This Option
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Game Controls */}
+      <div className="flex justify-center gap-4">
+        <Button 
+          onClick={advanceMonth} 
+          size="lg"
+          className="bg-blue-600 hover:bg-blue-700"
+          disabled={gameState.gameStatus !== 'playing'}
+        >
+          <Calendar className="w-4 h-4 mr-2" />
+          Advance Month
+        </Button>
+        <Button 
+          onClick={resetGame} 
+          variant="outline" 
+          size="lg"
+        >
+          <RefreshCw className="w-4 h-4 mr-2" />
+          Reset Game
+        </Button>
+      </div>
+
+      {/* Notifications */}
+      {notifications.length > 0 && (
+        <div className="fixed bottom-4 right-4 space-y-2 z-50">
+          {notifications.map((notification) => (
+            <Card key={notification.id} className={`
+              max-w-sm border-l-4 ${
+                notification.type === 'success' ? 'border-l-green-500 bg-green-50' :
+                notification.type === 'warning' ? 'border-l-yellow-500 bg-yellow-50' :
+                notification.type === 'error' ? 'border-l-red-500 bg-red-50' :
+                'border-l-blue-500 bg-blue-50'
+              }
+            `}>
+              <CardContent className="p-3">
+                <p className={`text-sm font-medium ${
+                  notification.type === 'success' ? 'text-green-800' :
+                  notification.type === 'warning' ? 'text-yellow-800' :
+                  notification.type === 'error' ? 'text-red-800' :
+                  'text-blue-800'
+                }`}>
+                  {notification.message}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+export default StartupJourney

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -172,3 +172,15 @@ Focused summary of learnings from Epic #2 (issues #3–#12).
 - Rendering recharts components inside Vitest requires a stable `ResizeObserver` mock and explicit container sizing—without that, `ResponsiveContainer` reports zero width and charts silently fail.
 - Encoding chart contracts as `ChartSeries`/`ChartSegment` types keeps lessons + activities in sync with UI expectations, and makes it trivial to swap in Supabase JSON without bespoke adapters.
 - Composing `FinancialDashboard` out of the shared chart primitives guarantees palette/ARIA consistency; whenever we need new dashboards, build them as orchestrations instead of net-new components.
+
+## PR #52 (Issue #34) - feat/34-task-11-business-simulations--part-a-3-components
+
+### Highlights
+- Landed the first trio of business simulations (LemonadeStand, StartupJourney, BudgetBalancer) under `components/business-simulations/` with fully data-driven configs, Supabase-friendly activity props, and persistence callbacks so lesson pages can save/restore state through `activity_submissions`.
+- Extended the activity schema/validator layer with `lemonade-stand`, `startup-journey`, and `budget-balancer` Zod contracts, keeping Supabase editors honest about supply costs, decision flows, and savings heuristics.
+- Added Vitest + RTL suites for all three simulations to assert config overrides, initial-state hydration, and `onStateChange` wiring before wiring them into routes, keeping lint/test/build green for these 2k+ lines of JSX.
+
+### Lessons
+- Notification queues inside long-running simulations need truly unique IDs; relying on `Date.now()` alone produced duplicate React keys once multiple alerts fired inside the same tick.
+- Deeply nested simulation state wants explicit merge helpers—rehydrating from persisted progress without them left stale inventory/decision objects in place.
+- Escaping apostrophes/quotes early saves a surprising amount of lint churn once educational copy (e.g., “Today’s Weather” / “End Month”) migrates over from v1.

--- a/lib/db/schema/activities.ts
+++ b/lib/db/schema/activities.ts
@@ -203,6 +203,130 @@ const cashFlowItemSchema = z.object({
   hint: z.string().optional()
 });
 
+const lemonadeInventorySchema = z.object({
+  lemons: z.number().int().nonnegative(),
+  sugar: z.number().int().nonnegative(),
+  cups: z.number().int().nonnegative()
+});
+
+const lemonadeRecipeSchema = z.object({
+  lemons: z.number().int().positive(),
+  sugar: z.number().int().nonnegative(),
+  price: z.number().positive()
+});
+
+const lemonadeDailySalesSchema = z.object({
+  cupsSold: z.number().int().nonnegative(),
+  dailyRevenue: z.number().nonnegative(),
+  dailyExpenses: z.number().nonnegative()
+});
+
+const lemonadeSupplyOptionSchema = z.object({
+  id: z.enum(['lemons', 'sugar', 'cups']),
+  label: z.string(),
+  quantity: z.number().int().positive(),
+  cost: z.number().positive(),
+  unit: z.string()
+});
+
+const lemonadeWeatherSchema = z.object({
+  id: z.string(),
+  emoji: z.string(),
+  description: z.string(),
+  multiplier: z.number().positive()
+});
+
+const lemonadeDemandSchema = z.object({
+  baseCustomers: z.object({
+    min: z.number().int().positive(),
+    max: z.number().int().positive()
+  }),
+  priceSensitivity: z.object({
+    highPriceThreshold: z.number().positive(),
+    highPriceMultiplier: z.number().positive(),
+    lowPriceThreshold: z.number().positive(),
+    lowPriceMultiplier: z.number().positive()
+  }),
+  recipeQualityRange: z.object({
+    min: z.number().positive(),
+    max: z.number().positive()
+  })
+});
+
+const lemonadeRecipeGuidanceSchema = z.object({
+  minimumStrength: z.number().positive(),
+  maximumStrength: z.number().positive(),
+  minimumPrice: z.number().positive(),
+  maximumPrice: z.number().positive()
+});
+
+const startupDecisionOptionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  effects: z.object({
+    funding: z.number().optional(),
+    burn: z.number().optional(),
+    users: z.number().optional(),
+    revenue: z.number().optional(),
+    growth: z.number().optional(),
+    revenuePerUser: z.number().optional()
+  })
+});
+
+const startupDecisionSchema = z.object({
+  id: z.string(),
+  type: z.enum(['funding', 'team', 'product', 'marketing', 'strategy']),
+  title: z.string(),
+  description: z.string(),
+  options: z.array(startupDecisionOptionSchema).min(1)
+});
+
+const startupStageSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  badgeClassName: z.string(),
+  progress: z.number().int().min(0).max(100),
+  icon: z.string().default('rocket')
+});
+
+const startupDecisionFlowSchema = z.object({
+  stageId: z.string(),
+  decisionIds: z.array(z.string())
+});
+
+const startupWinConditionSchema = z.object({
+  revenueTarget: z.number().nonnegative(),
+  timeLimitMonths: z.number().int().positive(),
+  timeLimitRevenueTarget: z.number().nonnegative(),
+  successStageId: z.string(),
+  successRevenueTarget: z.number().nonnegative()
+});
+
+const budgetExpenseConfigSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  required: z.boolean(),
+  defaultAmount: z.number().nonnegative(),
+  icon: z.string(),
+  color: z.string()
+});
+
+const budgetGameStateSchema = z.object({
+  monthlyIncome: z.number().positive(),
+  month: z.number().int().positive(),
+  totalSavings: z.number().nonnegative(),
+  emergencyFund: z.number().nonnegative(),
+  financialHealth: z.number().min(0).max(100)
+});
+
+const budgetSavingsConfigSchema = z.object({
+  emergencyFundContributionRate: z.number().min(0).max(1),
+  healthScoreBase: z.number(),
+  savingsMultiplier: z.number(),
+  emergencyMultiplier: z.number()
+});
+
 const financialStatementSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -373,6 +497,313 @@ export const activityPropsSchemas = {
     totalBudget: z.number(),
     constraints: z.record(z.string(), z.number()).optional(),
   }),
+  'lemonade-stand': z.object({
+    title: z.string().default('Lemonade Stand Tycoon'),
+    description: z.string().default('Run a lemonade stand to learn pricing, inventory, and profit.'),
+    supplyOptions: z.array(lemonadeSupplyOptionSchema).default([
+      { id: 'lemons', label: 'Fresh Lemons', quantity: 10, cost: 3, unit: 'bag' },
+      { id: 'sugar', label: 'Organic Sugar', quantity: 10, cost: 2, unit: 'bag' },
+      { id: 'cups', label: 'Compostable Cups', quantity: 20, cost: 1.5, unit: 'pack' }
+    ]),
+    weatherPatterns: z.array(lemonadeWeatherSchema).default([
+      { id: 'sunny', emoji: '☀️', description: 'Perfect lemonade weather!', multiplier: 1.5 },
+      { id: 'hot', emoji: '🔥', description: 'Everyone wants cold drinks!', multiplier: 2 },
+      { id: 'cloudy', emoji: '☁️', description: 'Moderate demand expected', multiplier: 0.8 },
+      { id: 'rainy', emoji: '🌧️', description: 'Few customers today', multiplier: 0.3 }
+    ]),
+    ingredientCosts: z
+      .object({
+        lemons: z.number().positive(),
+        sugar: z.number().positive(),
+        cup: z.number().positive()
+      })
+      .default({
+        lemons: 0.3,
+        sugar: 0.2,
+        cup: 0.075
+      }),
+    demand: lemonadeDemandSchema.default({
+      baseCustomers: { min: 20, max: 70 },
+      priceSensitivity: {
+        highPriceThreshold: 2,
+        highPriceMultiplier: 0.5,
+        lowPriceThreshold: 1,
+        lowPriceMultiplier: 1.2
+      },
+      recipeQualityRange: {
+        min: 0.3,
+        max: 1.5
+      }
+    }),
+    recipeGuidance: lemonadeRecipeGuidanceSchema.default({
+      minimumStrength: 2,
+      maximumStrength: 5,
+      minimumPrice: 0.5,
+      maximumPrice: 3
+    }),
+    initialState: z
+      .object({
+        cash: z.number().nonnegative().default(50),
+        day: z.number().int().positive().default(1),
+        revenue: z.number().nonnegative().default(0),
+        expenses: z.number().nonnegative().default(0),
+        inventory: lemonadeInventorySchema.default({
+          lemons: 0,
+          sugar: 0,
+          cups: 0
+        }),
+        recipe: lemonadeRecipeSchema.default({
+          lemons: 2,
+          sugar: 1,
+          price: 1
+        }),
+        weather: z.string().default('sunny'),
+        customerSatisfaction: z.number().min(0).max(100).default(100),
+        isSellingActive: z.boolean().default(false),
+        dailySales: lemonadeDailySalesSchema.default({
+          cupsSold: 0,
+          dailyRevenue: 0,
+          dailyExpenses: 0
+        }),
+        gameStatus: z.enum(['playing', 'ended']).default('playing')
+      })
+      .default({
+        cash: 50,
+        day: 1,
+        revenue: 0,
+        expenses: 0,
+        inventory: { lemons: 0, sugar: 0, cups: 0 },
+        recipe: { lemons: 2, sugar: 1, price: 1 },
+        weather: 'sunny',
+        customerSatisfaction: 100,
+        isSellingActive: false,
+        dailySales: { cupsSold: 0, dailyRevenue: 0, dailyExpenses: 0 },
+        gameStatus: 'playing'
+      })
+  }),
+  'startup-journey': z.object({
+    title: z.string().default('Startup Journey'),
+    description: z
+      .string()
+      .default('Build a tech startup from idea to success and balance funding, growth, and strategy.'),
+    stages: z
+      .array(startupStageSchema)
+      .min(1)
+      .default([
+        { id: 'idea', name: 'Idea', badgeClassName: 'bg-yellow-100 text-yellow-800 border-yellow-300', progress: 20, icon: 'lightbulb' },
+        { id: 'prototype', name: 'Prototype', badgeClassName: 'bg-blue-100 text-blue-800 border-blue-300', progress: 40, icon: 'code' },
+        { id: 'launch', name: 'Launch', badgeClassName: 'bg-purple-100 text-purple-800 border-purple-300', progress: 60, icon: 'rocket' },
+        { id: 'growth', name: 'Growth', badgeClassName: 'bg-green-100 text-green-800 border-green-300', progress: 80, icon: 'chart-line' },
+        { id: 'success', name: 'Success', badgeClassName: 'bg-amber-100 text-amber-800 border-amber-300', progress: 100, icon: 'crown' }
+      ]),
+    decisions: z.array(startupDecisionSchema).default([
+      {
+        id: 'initial-funding',
+        type: 'funding',
+        title: 'Initial Funding Strategy',
+        description: 'You have a great app idea! How will you fund development?',
+        options: [
+          {
+            id: 'bootstrap',
+            title: 'Bootstrap with Personal Savings',
+            description: 'Use $5,000 of your own money. Lower burn rate but limited resources.',
+            effects: { funding: 5000, burn: -500 }
+          },
+          {
+            id: 'accelerator',
+            title: 'Apply to Startup Accelerator',
+            description: 'Get $25,000 funding plus mentorship and network access.',
+            effects: { funding: 25000, users: 100, growth: 0.2 }
+          },
+          {
+            id: 'angel-investors',
+            title: 'Pitch to Angel Investors',
+            description: 'Raise $100,000 but higher pressure and burn rate.',
+            effects: { funding: 100000, burn: 6000 }
+          }
+        ]
+      },
+      {
+        id: 'team-building',
+        type: 'team',
+        title: 'First Hire Decision',
+        description: 'Your startup is gaining traction. Who should you hire first?',
+        options: [
+          {
+            id: 'developer',
+            title: 'Senior Developer',
+            description: 'Accelerate product development and add new features.',
+            effects: { burn: 5000, growth: 0.3 }
+          },
+          {
+            id: 'marketer',
+            title: 'Marketing Manager',
+            description: 'Focus on user acquisition and brand building.',
+            effects: { burn: 3000, users: 500, growth: 0.5 }
+          },
+          {
+            id: 'business-dev',
+            title: 'Business Development',
+            description: 'Build partnerships and explore revenue opportunities.',
+            effects: { burn: 4000, revenue: 1000, revenuePerUser: 2 }
+          }
+        ]
+      },
+      {
+        id: 'product-focus',
+        type: 'product',
+        title: 'Product Development Priority',
+        description: 'Limited development resources. What should be your focus?',
+        options: [
+          {
+            id: 'new-features',
+            title: 'Build New Features',
+            description: 'Add functionality to attract more users.',
+            effects: { users: 300, burn: 2000 }
+          },
+          {
+            id: 'user-feedback',
+            title: 'Focus on User Feedback',
+            description: 'Improve existing features based on user input.',
+            effects: { growth: 0.4, revenuePerUser: 1 }
+          },
+          {
+            id: 'scaling',
+            title: 'Technical Scaling',
+            description: 'Prepare infrastructure for rapid growth.',
+            effects: { burn: 3000, growth: 0.6 }
+          }
+        ]
+      },
+      {
+        id: 'marketing-strategy',
+        type: 'marketing',
+        title: 'Growth Strategy',
+        description: 'How will you acquire your next 1000 users?',
+        options: [
+          {
+            id: 'paid-ads',
+            title: 'Paid Advertising',
+            description: 'Invest in Facebook and Google ads for rapid acquisition.',
+            effects: { users: 800, burn: 5000 }
+          },
+          {
+            id: 'content-marketing',
+            title: 'Content Marketing',
+            description: 'Build organic growth through valuable content.',
+            effects: { users: 300, growth: 0.3, burn: 1000 }
+          },
+          {
+            id: 'partnerships',
+            title: 'Strategic Partnerships',
+            description: 'Partner with established companies for user access.',
+            effects: { users: 600, revenue: 2000, burn: 2000 }
+          }
+        ]
+      },
+      {
+        id: 'revenue-model',
+        type: 'strategy',
+        title: 'Monetization Strategy',
+        description: "Time to start generating revenue. What's your approach?",
+        options: [
+          {
+            id: 'freemium',
+            title: 'Freemium Model',
+            description: 'Free basic version with premium features.',
+            effects: { revenuePerUser: 3, growth: 0.2 }
+          },
+          {
+            id: 'subscription',
+            title: 'Monthly Subscription',
+            description: 'Recurring revenue but may slow user growth.',
+            effects: { revenuePerUser: 8, growth: -0.1 }
+          },
+          {
+            id: 'enterprise',
+            title: 'Enterprise Sales',
+            description: 'Target businesses with high-value contracts.',
+            effects: { revenuePerUser: 15, burn: 3000, users: -100 }
+          }
+        ]
+      }
+    ]),
+    decisionFlow: z
+      .array(startupDecisionFlowSchema)
+      .default([
+        { stageId: 'idea', decisionIds: ['initial-funding'] },
+        { stageId: 'prototype', decisionIds: ['team-building', 'product-focus'] },
+        { stageId: 'launch', decisionIds: ['marketing-strategy'] },
+        { stageId: 'growth', decisionIds: ['revenue-model'] },
+        { stageId: 'success', decisionIds: [] }
+      ]),
+    winConditions: startupWinConditionSchema.default({
+      revenueTarget: 50000,
+      successRevenueTarget: 50000,
+      timeLimitMonths: 24,
+      timeLimitRevenueTarget: 20000,
+      successStageId: 'success'
+    }),
+    initialState: z
+      .object({
+        stage: z.string().default('idea'),
+        funding: z.number().nonnegative().default(10000),
+        monthlyBurn: z.number().nonnegative().default(2000),
+        users: z.number().nonnegative().default(100),
+        revenue: z.number().nonnegative().default(0),
+        month: z.number().int().positive().default(1),
+        maxMonths: z.number().int().positive().default(24),
+        decisions: z.array(z.string()).default([]),
+        currentDecisionId: z.string().nullable().default('initial-funding'),
+        userGrowthRate: z.number().nonnegative().default(0.1),
+        revenuePerUser: z.number().nonnegative().default(0),
+        gameStatus: z.enum(['playing', 'won', 'lost']).default('playing')
+      })
+      .default({
+        stage: 'idea',
+        funding: 10000,
+        monthlyBurn: 2000,
+        users: 100,
+        revenue: 0,
+        month: 1,
+        maxMonths: 24,
+        decisions: [],
+        currentDecisionId: 'initial-funding',
+        userGrowthRate: 0.1,
+        revenuePerUser: 0,
+        gameStatus: 'playing'
+      })
+  }),
+  'budget-balancer': z.object({
+    title: z.string().default('Budget Balancer'),
+    description: z
+      .string()
+      .default('Manage monthly income, required bills, and discretionary spending to build savings.'),
+    expenses: z
+      .array(budgetExpenseConfigSchema)
+      .default([
+        { id: 'rent', label: 'Rent', required: true, defaultAmount: 1200, icon: 'home', color: 'bg-blue-500' },
+        { id: 'utilities', label: 'Utilities', required: true, defaultAmount: 300, icon: 'zap', color: 'bg-yellow-500' },
+        { id: 'groceries', label: 'Groceries', required: true, defaultAmount: 400, icon: 'shopping-cart', color: 'bg-green-500' },
+        { id: 'transportation', label: 'Transportation', required: true, defaultAmount: 200, icon: 'car', color: 'bg-purple-500' },
+        { id: 'entertainment', label: 'Entertainment', required: false, defaultAmount: 0, icon: 'coffee', color: 'bg-pink-500' },
+        { id: 'dining', label: 'Dining', required: false, defaultAmount: 0, icon: 'utensils', color: 'bg-orange-500' },
+        { id: 'shopping', label: 'Shopping', required: false, defaultAmount: 0, icon: 'shopping-bag', color: 'bg-indigo-500' }
+      ]),
+    savingsConfig: budgetSavingsConfigSchema.default({
+      emergencyFundContributionRate: 0.1,
+      healthScoreBase: 50,
+      savingsMultiplier: 50,
+      emergencyMultiplier: 25
+    }),
+    initialState: budgetGameStateSchema.default({
+      monthlyIncome: 5000,
+      month: 1,
+      totalSavings: 1000,
+      emergencyFund: 500,
+      financialHealth: 100
+    })
+  }),
 } as const;
 
 export type ActivityComponentKey = keyof typeof activityPropsSchemas;
@@ -396,6 +827,9 @@ export type FillInTheBlankActivityProps = z.infer<typeof activityPropsSchemas['f
 export type JournalEntryActivityProps = z.infer<typeof activityPropsSchemas['journal-entry-building']>;
 export type ReflectionJournalActivityProps = z.infer<typeof activityPropsSchemas['reflection-journal']>;
 export type PeerCritiqueActivityProps = z.infer<typeof activityPropsSchemas['peer-critique-form']>;
+export type LemonadeStandActivityProps = z.infer<typeof activityPropsSchemas['lemonade-stand']>;
+export type StartupJourneyActivityProps = z.infer<typeof activityPropsSchemas['startup-journey']>;
+export type BudgetBalancerActivityProps = z.infer<typeof activityPropsSchemas['budget-balancer']>;
 
 export const gradingConfigSchema = z.object({
   autoGrade: z.boolean().default(false),

--- a/lib/db/schema/validators.ts
+++ b/lib/db/schema/validators.ts
@@ -32,7 +32,10 @@ const activityPropsSchema = z.union([
   activityPropsSchemas['reflection-journal'],
   activityPropsSchemas['peer-critique-form'],
   activityPropsSchemas['profit-calculator'],
-  activityPropsSchemas['budget-worksheet']
+  activityPropsSchemas['budget-worksheet'],
+  activityPropsSchemas['lemonade-stand'],
+  activityPropsSchemas['startup-journey'],
+  activityPropsSchemas['budget-balancer']
 ]);
 
 const jsonRecordSchema = z.record(z.string(), z.unknown());


### PR DESCRIPTION
Closes #34

## Summary
- migrate LemonadeStand, StartupJourney, BudgetBalancer components with Supabase-driven props and persistence hooks
- extend activity schemas/validators to cover the new simulation configs
- add Vitest suites plus lint/test/build evidence for the new surface area