### PR TITLE
feat: migrate teacher components from v1 (#37)

### DIFF
--- a/components/teacher/TeacherLessonPlan.test.tsx
+++ b/components/teacher/TeacherLessonPlan.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TeacherLessonPlan } from './TeacherLessonPlan';
+import { type Lesson, type Phase } from '@/lib/db/schema/validators';
+
+describe('TeacherLessonPlan', () => {
+  const mockLesson: Lesson = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    unitNumber: 1,
+    title: 'Introduction to Accounting Equation',
+    slug: 'intro-to-accounting-equation',
+    description: 'Students will learn the fundamental accounting equation and how to apply it to real business scenarios.',
+    learningObjectives: [
+      'Identify the key components of the accounting equation',
+      'Explain why accurate financial records are essential',
+      'Apply the accounting equation to business transactions'
+    ],
+    orderIndex: 1,
+    metadata: {
+      duration: 45,
+      difficulty: 'beginner',
+      tags: ['accounting-equation', 'fundamentals', 'business-transactions']
+    },
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+  };
+
+  const mockPhases: Phase[] = [
+    {
+      id: 'phase-1',
+      lessonId: mockLesson.id,
+      phaseNumber: 1,
+      title: 'Hook',
+      contentBlocks: [
+        {
+          id: '1',
+          type: 'markdown',
+          content: 'Students watch an introduction video about a startup business.'
+        }
+      ],
+      estimatedMinutes: 8,
+      metadata: {
+        color: 'red',
+        icon: 'play',
+        phaseType: 'intro'
+      },
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+    },
+    {
+      id: 'phase-2',
+      lessonId: mockLesson.id,
+      phaseNumber: 2,
+      title: 'Introduction',
+      contentBlocks: [
+        {
+          id: '2',
+          type: 'markdown',
+          content: 'Brief overview of the accounting equation.'
+        },
+        {
+          id: '3',
+          type: 'callout',
+          variant: 'why-this-matters',
+          content: 'Understanding the accounting equation is foundational to all business operations.'
+        }
+      ],
+      estimatedMinutes: 10,
+      metadata: {
+        color: 'blue',
+        icon: 'book',
+        phaseType: 'intro'
+      },
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+    }
+  ];
+
+  it('renders lesson title and number', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Unit 1 - Lesson 1')).toBeInTheDocument();
+    expect(screen.getByText('Introduction to Accounting Equation')).toBeInTheDocument();
+  });
+
+  it('renders lesson duration', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('45 minutes')).toBeInTheDocument();
+  });
+
+  it('renders learning objectives', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Learning Objectives')).toBeInTheDocument();
+    expect(screen.getByText(/Identify the key components/)).toBeInTheDocument();
+    expect(screen.getByText(/Explain why accurate financial records/)).toBeInTheDocument();
+  });
+
+  it('renders key concepts from tags', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Key Concepts')).toBeInTheDocument();
+    expect(screen.getByText('accounting-equation')).toBeInTheDocument();
+    expect(screen.getByText('fundamentals')).toBeInTheDocument();
+  });
+
+  it('renders teaching strategies', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Teaching Strategies')).toBeInTheDocument();
+    expect(screen.getByText('Interactive instruction')).toBeInTheDocument();
+    expect(screen.getByText('Guided practice')).toBeInTheDocument();
+  });
+
+  it('renders lesson rationale from description', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Lesson Rationale')).toBeInTheDocument();
+    expect(screen.getByText(/Students will learn the fundamental accounting equation/)).toBeInTheDocument();
+  });
+
+  it('renders lesson phases when provided', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} phases={mockPhases} lessonNumber={1} />);
+
+    expect(screen.getByText('Lesson Phases')).toBeInTheDocument();
+    expect(screen.getByText('Phase 1: Hook')).toBeInTheDocument();
+    expect(screen.getByText('Phase 2: Introduction')).toBeInTheDocument();
+  });
+
+  it('renders phase content blocks', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} phases={mockPhases} lessonNumber={1} />);
+
+    expect(screen.getByText(/Students watch an introduction video/)).toBeInTheDocument();
+    expect(screen.getByText(/Brief overview of the accounting equation/)).toBeInTheDocument();
+  });
+
+  it('renders callout blocks with correct styling', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} phases={mockPhases} lessonNumber={1} />);
+
+    expect(screen.getByText('Why This Matters')).toBeInTheDocument();
+    expect(screen.getByText(/Understanding the accounting equation is foundational/)).toBeInTheDocument();
+  });
+
+  it('displays phase estimated minutes', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} phases={mockPhases} lessonNumber={1} />);
+
+    expect(screen.getByText('8 min')).toBeInTheDocument();
+    expect(screen.getByText('10 min')).toBeInTheDocument();
+  });
+
+  it('renders differentiation strategies', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Differentiation Strategies')).toBeInTheDocument();
+    expect(screen.getByText('ELL Support')).toBeInTheDocument();
+    expect(screen.getByText('Special Needs')).toBeInTheDocument();
+    expect(screen.getByText('Gifted Extension')).toBeInTheDocument();
+  });
+
+  it('renders required materials section', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    expect(screen.getByText('Required Materials')).toBeInTheDocument();
+    expect(screen.getByText('Technology')).toBeInTheDocument();
+    expect(screen.getByText('Physical Materials')).toBeInTheDocument();
+  });
+
+  it('calls onNavigate when navigation buttons clicked', async () => {
+    const mockNavigate = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TeacherLessonPlan
+        lesson={mockLesson}
+        lessonNumber={1}
+        onNavigate={mockNavigate}
+      />
+    );
+
+    const prevButton = screen.getByTitle('Previous lesson');
+    const nextButton = screen.getByTitle('Next lesson');
+
+    await user.click(prevButton);
+    expect(mockNavigate).toHaveBeenCalledWith('prev');
+
+    await user.click(nextButton);
+    expect(mockNavigate).toHaveBeenCalledWith('next');
+  });
+
+  it('calls onLessonChange when lesson selector changed', async () => {
+    const mockLessonChange = vi.fn();
+    const user = userEvent.setup();
+
+    const availableLessons = [
+      { number: 1, title: 'Introduction' },
+      { number: 2, title: 'Core Concepts' },
+      { number: 3, title: 'Practice' }
+    ];
+
+    render(
+      <TeacherLessonPlan
+        lesson={mockLesson}
+        lessonNumber={1}
+        availableLessons={availableLessons}
+        onLessonChange={mockLessonChange}
+      />
+    );
+
+    const selector = screen.getByLabelText('Jump to:');
+    await user.selectOptions(selector, '2');
+
+    expect(mockLessonChange).toHaveBeenCalledWith(2);
+  });
+
+  it('renders teacher guidance for phases', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} phases={mockPhases} lessonNumber={1} />);
+
+    // Multiple phases mean multiple guidance sections
+    const teachingTips = screen.getAllByText('Teaching Tips');
+    expect(teachingTips.length).toBeGreaterThan(0);
+
+    const timingGuidance = screen.getAllByText('Timing Guidance');
+    expect(timingGuidance.length).toBeGreaterThan(0);
+
+    const keyMaterials = screen.getAllByText('Key Materials');
+    expect(keyMaterials.length).toBeGreaterThan(0);
+  });
+
+  it('handles lesson without phases gracefully', () => {
+    render(<TeacherLessonPlan lesson={mockLesson} lessonNumber={1} />);
+
+    // Should render overview but not phases section
+    expect(screen.getByText('Lesson Overview')).toBeInTheDocument();
+    expect(screen.queryByText('Lesson Phases')).not.toBeInTheDocument();
+  });
+
+  it('handles lesson without learning objectives', () => {
+    const lessonWithoutObjectives: Lesson = {
+      ...mockLesson,
+      learningObjectives: null
+    };
+
+    render(<TeacherLessonPlan lesson={lessonWithoutObjectives} lessonNumber={1} />);
+
+    // Should still render but without objectives section
+    expect(screen.getByText('Lesson Overview')).toBeInTheDocument();
+    expect(screen.queryByText('Learning Objectives')).not.toBeInTheDocument();
+  });
+
+  it('uses default duration when not specified in metadata', () => {
+    const lessonWithoutDuration: Lesson = {
+      ...mockLesson,
+      metadata: null
+    };
+
+    render(<TeacherLessonPlan lesson={lessonWithoutDuration} lessonNumber={1} />);
+
+    expect(screen.getByText('45 minutes')).toBeInTheDocument();
+  });
+
+  it('renders all six phase numbers with correct icons', () => {
+    const allPhases: Phase[] = [1, 2, 3, 4, 5, 6].map(num => ({
+      id: `phase-${num}`,
+      lessonId: mockLesson.id,
+      phaseNumber: num,
+      title: `Phase ${num}`,
+      contentBlocks: [{ id: `${num}`, type: 'markdown' as const, content: `Phase ${num} content` }],
+      estimatedMinutes: 10,
+      metadata: { phaseType: 'intro' as const },
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+    }));
+
+    render(<TeacherLessonPlan lesson={mockLesson} phases={allPhases} lessonNumber={1} />);
+
+    // Verify all phases render
+    expect(screen.getByText('Phase 1: Phase 1')).toBeInTheDocument();
+    expect(screen.getByText('Phase 6: Phase 6')).toBeInTheDocument();
+  });
+});

--- a/components/teacher/TeacherLessonPlan.tsx
+++ b/components/teacher/TeacherLessonPlan.tsx
@@ -1,0 +1,471 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Target,
+  CheckCircle,
+  BookOpen,
+  Clock,
+  Users,
+  Settings,
+  Lightbulb,
+  FileText,
+  ChevronLeft,
+  ChevronRight,
+  PlayCircle,
+  PenTool,
+  UserCheck,
+  Flag,
+  Info,
+  ChevronDown
+} from "lucide-react"
+import { type Lesson, type Phase } from '@/lib/db/schema/validators';
+
+interface TeacherLessonPlanProps {
+  lesson: Lesson;
+  phases?: Phase[];
+  lessonNumber: number;
+  gradeLevel?: string;
+  course?: string;
+  onNavigate?: (direction: 'prev' | 'next') => void;
+  onLessonChange?: (lessonNumber: number) => void;
+  availableLessons?: Array<{ number: number; title: string }>;
+}
+
+export function TeacherLessonPlan({
+  lesson,
+  phases = [],
+  lessonNumber,
+  onNavigate,
+  onLessonChange,
+  availableLessons = []
+}: TeacherLessonPlanProps) {
+  const durationMinutes = lesson.metadata?.duration || 45;
+  const learningObjectives = lesson.learningObjectives || [];
+
+  // Default pedagogical approaches based on lesson content
+  const pedagogicalApproach = [
+    'Interactive instruction',
+    'Guided practice',
+    'Collaborative learning',
+    'Formative assessment'
+  ];
+
+  const getPhaseIcon = (phaseNumber: number) => {
+    switch (phaseNumber) {
+      case 1: return <PlayCircle className="h-5 w-5" />
+      case 2: return <BookOpen className="h-5 w-5" />
+      case 3: return <Users className="h-5 w-5" />
+      case 4: return <PenTool className="h-5 w-5" />
+      case 5: return <UserCheck className="h-5 w-5" />
+      case 6: return <Flag className="h-5 w-5" />
+      default: return <Info className="h-5 w-5" />
+    }
+  }
+
+  const getPhaseColor = (phaseNumber: number) => {
+    switch (phaseNumber) {
+      case 1: return 'border-red-200 bg-red-50 dark:bg-red-950/10'
+      case 2: return 'border-blue-200 bg-blue-50 dark:bg-blue-950/10'
+      case 3: return 'border-green-200 bg-green-50 dark:bg-green-950/10'
+      case 4: return 'border-purple-200 bg-purple-50 dark:bg-purple-950/10'
+      case 5: return 'border-amber-200 bg-amber-50 dark:bg-amber-950/10'
+      case 6: return 'border-slate-200 bg-slate-50 dark:bg-slate-950/10'
+      default: return 'border-gray-200 bg-gray-50 dark:bg-gray-950/10'
+    }
+  }
+
+  const getPhaseTiming = (phaseNumber: number) => {
+    switch (phaseNumber) {
+      case 1: return '5-8 min'
+      case 2: return '8-12 min'
+      case 3: return '15-20 min'
+      case 4: return '10-15 min'
+      case 5: return '3-5 min'
+      case 6: return '2-3 min'
+      default: return '5-10 min'
+    }
+  }
+
+  const getPhaseName = (phaseNumber: number) => {
+    switch (phaseNumber) {
+      case 1: return 'Hook'
+      case 2: return 'Introduction'
+      case 3: return 'Guided Practice'
+      case 4: return 'Independent Practice'
+      case 5: return 'Assessment'
+      case 6: return 'Closing'
+      default: return `Phase ${phaseNumber}`
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Header Navigation */}
+      <div className="flex items-center justify-between bg-white dark:bg-gray-900 p-4 rounded-lg border shadow-sm">
+        <div className="flex items-center gap-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Unit {lesson.unitNumber} - Lesson {lessonNumber}
+            </h1>
+            <p className="text-sm text-gray-600 dark:text-gray-400">{lesson.title}</p>
+          </div>
+
+          {availableLessons.length > 0 && onLessonChange && (
+            <div className="flex items-center gap-2">
+              <label htmlFor="lesson-selector" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Jump to:
+              </label>
+              <div className="relative">
+                <select
+                  id="lesson-selector"
+                  value={lessonNumber}
+                  onChange={(e) => onLessonChange(parseInt(e.target.value))}
+                  className="appearance-none bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary min-w-[280px]"
+                >
+                  {availableLessons.map((lessonOption) => (
+                    <option key={lessonOption.number} value={lessonOption.number}>
+                      Lesson {lessonOption.number}: {lessonOption.title}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <Clock className="h-4 w-4" />
+            <span>{durationMinutes} minutes</span>
+          </div>
+
+          {/* Quick Previous/Next for adjacent lessons */}
+          {onNavigate && (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onNavigate('prev')}
+                className="p-2"
+                title="Previous lesson"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onNavigate('next')}
+                className="p-2"
+                title="Next lesson"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Lesson Overview */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Target className="h-6 w-6 text-primary" />
+            Lesson Overview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Learning Objectives */}
+          {learningObjectives.length > 0 && (
+            <div>
+              <h3 className="text-lg font-semibold mb-3">Learning Objectives</h3>
+              <div className="bg-blue-50 dark:bg-blue-950/10 p-4 rounded-lg">
+                <p className="text-sm text-blue-800 dark:text-blue-200 mb-2 font-medium">
+                  Students will be able to:
+                </p>
+                <ul className="space-y-2">
+                  {learningObjectives.map((objective, index) => (
+                    <li key={index} className="flex items-start gap-2 text-blue-700 dark:text-blue-300">
+                      <CheckCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                      <span className="text-sm">{objective}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+
+          {/* Key Concepts */}
+          {lesson.metadata?.tags && lesson.metadata.tags.length > 0 && (
+            <div>
+              <h3 className="text-lg font-semibold mb-3">Key Concepts</h3>
+              <div className="grid grid-cols-2 gap-2">
+                {lesson.metadata.tags.map((tag, index) => (
+                  <Badge key={index} variant="secondary" className="text-xs p-2 justify-start">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Pedagogical Approach */}
+          <div>
+            <h3 className="text-lg font-semibold mb-3">Teaching Strategies</h3>
+            <div className="flex flex-wrap gap-2">
+              {pedagogicalApproach.map((approach, index) => (
+                <Badge key={index} variant="outline" className="text-xs">
+                  {approach}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {/* Rationale */}
+          {lesson.description && (
+            <div>
+              <h3 className="text-lg font-semibold mb-3">Lesson Rationale</h3>
+              <p className="text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 p-4 rounded-lg italic">
+                {lesson.description}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Lesson Phases */}
+      {phases.length > 0 && (
+        <div className="space-y-6">
+          <h2 className="text-2xl font-bold flex items-center gap-2">
+            <BookOpen className="h-6 w-6 text-primary" />
+            Lesson Phases
+          </h2>
+
+          {phases.map((phase) => (
+            <Card key={phase.id} className={`${getPhaseColor(phase.phaseNumber)} border-l-4`}>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {getPhaseIcon(phase.phaseNumber)}
+                    <span>Phase {phase.phaseNumber}: {phase.title || getPhaseName(phase.phaseNumber)}</span>
+                  </div>
+                  <Badge variant="secondary">{phase.estimatedMinutes ? `${phase.estimatedMinutes} min` : getPhaseTiming(phase.phaseNumber)}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {/* Phase content blocks */}
+                {phase.contentBlocks.map((block, blockIndex) => (
+                  <div key={blockIndex} className="mb-4">
+                    {block.type === 'markdown' && (
+                      <p className="text-gray-700 dark:text-gray-300">
+                        {block.content}
+                      </p>
+                    )}
+                    {block.type === 'callout' && (
+                      <div className="bg-amber-50 dark:bg-amber-950/10 border border-amber-200 dark:border-amber-800 p-3 rounded-lg">
+                        <div className="flex items-center gap-2 mb-2">
+                          <Settings className="h-4 w-4 text-amber-600" />
+                          <span className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                            {block.variant === 'why-this-matters' ? 'Why This Matters' :
+                             block.variant === 'tip' ? 'Teaching Tip' :
+                             block.variant === 'warning' ? 'Important' : 'Example'}
+                          </span>
+                        </div>
+                        <p className="text-sm text-amber-700 dark:text-amber-300">
+                          {block.content}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {/* Phase-specific guidance */}
+                <div className="mt-4 space-y-3">
+                  <TeacherGuidance phaseNumber={phase.phaseNumber} />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Differentiation Strategies */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-6 w-6 text-primary" />
+            Differentiation Strategies
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid md:grid-cols-3 gap-6">
+            <div>
+              <h4 className="font-semibold text-green-700 dark:text-green-300 mb-2">
+                ELL Support
+              </h4>
+              <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-400">
+                <li>• Visual aids and diagrams</li>
+                <li>• Peer translation support</li>
+                <li>• Simplified vocabulary sheets</li>
+                <li>• Extended processing time</li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold text-blue-700 dark:text-blue-300 mb-2">
+                Special Needs
+              </h4>
+              <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-400">
+                <li>• Step-by-step checklists</li>
+                <li>• Audio instructions</li>
+                <li>• Reduced cognitive load</li>
+                <li>• Frequent check-ins</li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold text-purple-700 dark:text-purple-300 mb-2">
+                Gifted Extension
+              </h4>
+              <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-400">
+                <li>• Advanced problem scenarios</li>
+                <li>• Leadership roles in groups</li>
+                <li>• Research extensions</li>
+                <li>• Peer mentoring opportunities</li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Materials and Resources */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-6 w-6 text-primary" />
+            Required Materials
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div>
+              <h4 className="font-semibold mb-3">Technology</h4>
+              <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-400">
+                <li>• Computer/tablet for each student</li>
+                <li>• Projector/interactive whiteboard</li>
+                <li>• Excel or Google Sheets access</li>
+                <li>• Video playback capability</li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold mb-3">Physical Materials</h4>
+              <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-400">
+                <li>• Lesson handouts</li>
+                <li>• Practice worksheets</li>
+                <li>• Sticky notes for activities</li>
+                <li>• Exit ticket forms</li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// Helper component for phase-specific teacher guidance
+function TeacherGuidance({ phaseNumber }: { phaseNumber: number }) {
+  const guidance: Record<number, { tips: string[]; timing: string; materials: string }> = {
+    1: {
+      tips: [
+        "Ensure media is ready and tested before class",
+        "Have students note key observations",
+        "Use think-pair-share to discuss initial impressions"
+      ],
+      timing: "Keep engaging and focused, 5-8 minutes total",
+      materials: "Media files, notebook/digital notes"
+    },
+    2: {
+      tips: [
+        "Connect to students' prior knowledge",
+        "Use real examples from local context",
+        "Preview the lesson's practical applications"
+      ],
+      timing: "8-10 minutes of direct instruction with interaction",
+      materials: "Slides, examples, visual aids"
+    },
+    3: {
+      tips: [
+        "Circulate and listen to student discussions",
+        "Encourage students to explain their reasoning",
+        "Collect common misconceptions for whole-class discussion"
+      ],
+      timing: "15-18 minutes with structured practice",
+      materials: "Practice materials, discussion prompts"
+    },
+    4: {
+      tips: [
+        "Monitor individual progress closely",
+        "Provide immediate feedback",
+        "Allow students to work at their own pace"
+      ],
+      timing: "10-12 minutes of focused individual work",
+      materials: "Individual practice materials"
+    },
+    5: {
+      tips: [
+        "Use formative assessment to gauge understanding",
+        "Look for misconceptions to address next lesson",
+        "Keep assessment low-stakes and supportive"
+      ],
+      timing: "3-5 minutes for quick formative check",
+      materials: "Assessment materials (digital or paper)"
+    },
+    6: {
+      tips: [
+        "Make explicit connections to lesson objectives",
+        "Preview next lesson to build anticipation",
+        "Thank students for engagement and participation"
+      ],
+      timing: "2-3 minutes of wrap-up and preview",
+      materials: "Summary materials, preview slides"
+    }
+  };
+
+  const phaseGuidance = guidance[phaseNumber];
+
+  if (!phaseGuidance) return null;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border">
+      <div className="grid md:grid-cols-3 gap-4 text-sm">
+        <div>
+          <h5 className="font-medium text-primary mb-2">Teaching Tips</h5>
+          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
+            {phaseGuidance.tips.map((tip, index) => (
+              <li key={index} className="flex items-start gap-2">
+                <Lightbulb className="h-3 w-3 mt-1 flex-shrink-0" />
+                {tip}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h5 className="font-medium text-primary mb-2">Timing Guidance</h5>
+          <p className="text-gray-600 dark:text-gray-400 flex items-start gap-2">
+            <Clock className="h-3 w-3 mt-1 flex-shrink-0" />
+            {phaseGuidance.timing}
+          </p>
+        </div>
+        <div>
+          <h5 className="font-medium text-primary mb-2">Key Materials</h5>
+          <p className="text-gray-600 dark:text-gray-400 flex items-start gap-2">
+            <FileText className="h-3 w-3 mt-1 flex-shrink-0" />
+            {phaseGuidance.materials}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/teacher/UnitLessonPlan.test.tsx
+++ b/components/teacher/UnitLessonPlan.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UnitLessonPlan } from './UnitLessonPlan';
+import { type Lesson } from '@/lib/db/schema/validators';
+
+describe('UnitLessonPlan', () => {
+  const mockLesson: Lesson = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    unitNumber: 1,
+    title: 'Balance by Design',
+    slug: 'balance-by-design',
+    description: 'Learn the fundamental accounting equation',
+    learningObjectives: null,
+    orderIndex: 1,
+    metadata: {
+      duration: 120,
+      durationLabel: '3-4 weeks',
+      difficulty: 'beginner',
+      tags: ['accounting'],
+      unitContent: {
+        drivingQuestion: {
+          question: 'How can a business track what it owns and owes?',
+          context: 'Business scenario'
+        },
+        objectives: {
+          content: ['Financial analysis', 'Business communication'],
+          skills: ['Excel formulas', 'Data visualization'],
+          deliverables: ['Financial statement']
+        },
+        assessment: {
+          performanceTask: {
+            title: 'Create Balance Sheet',
+            description: 'Complete balance sheet for business',
+            requirements: ['Accurate classification', 'Proper formatting'],
+            context: 'Real business scenario'
+          },
+          milestones: [
+            {
+              id: 'm1',
+              day: 5,
+              title: 'Asset Identification',
+              description: 'Identify assets',
+              criteria: ['Classify 5 assets']
+            }
+          ],
+          rubric: [
+            {
+              name: 'Accuracy',
+              weight: '40%',
+              exemplary: 'All correct',
+              proficient: 'Most correct',
+              developing: 'Some correct'
+            }
+          ]
+        },
+        learningSequence: {
+          weeks: [
+            {
+              weekNumber: 1,
+              title: 'Foundation Week',
+              description: 'Build core concepts',
+              days: []
+            }
+          ]
+        },
+        prerequisites: {
+          knowledge: ['Basic math'],
+          technology: ['Excel'],
+          resources: []
+        }
+      }
+    },
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+  };
+
+  it('renders unit title and description', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Unit 1: Balance by Design')).toBeInTheDocument();
+    expect(screen.getByText(/fundamental accounting equation/)).toBeInTheDocument();
+  });
+
+  it('renders Stage 1: Desired Results section', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Stage 1: Identify Desired Results')).toBeInTheDocument();
+  });
+
+  it('renders essential question', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Essential Question')).toBeInTheDocument();
+    expect(screen.getByText(/How can a business track/)).toBeInTheDocument();
+  });
+
+  it('renders enduring understandings', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Enduring Understandings')).toBeInTheDocument();
+
+    // Financial analysis appears in multiple sections, so use getAllByText
+    const financialAnalysis = screen.getAllByText('Financial analysis');
+    expect(financialAnalysis.length).toBeGreaterThan(0);
+  });
+
+  it('renders knowledge and skills sections', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Students will know...')).toBeInTheDocument();
+    expect(screen.getByText('Students will be able to...')).toBeInTheDocument();
+
+    // Excel formulas appears in multiple sections, so use getAllByText
+    const excelFormulas = screen.getAllByText('Excel formulas');
+    expect(excelFormulas.length).toBeGreaterThan(0);
+  });
+
+  it('renders Stage 2: Assessment Evidence section', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Stage 2: Determine Acceptable Evidence')).toBeInTheDocument();
+  });
+
+  it('renders performance task', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Performance Task (Summative Assessment)')).toBeInTheDocument();
+    expect(screen.getByText('Create Balance Sheet')).toBeInTheDocument();
+    expect(screen.getByText(/Complete balance sheet/)).toBeInTheDocument();
+  });
+
+  it('renders milestones', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Milestone Assessments (Formative)')).toBeInTheDocument();
+    expect(screen.getByText('Asset Identification')).toBeInTheDocument();
+    expect(screen.getByText('Day 5')).toBeInTheDocument();
+  });
+
+  it('renders rubric table', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Success Criteria & Rubric')).toBeInTheDocument();
+    expect(screen.getByText('Accuracy')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByText('All correct')).toBeInTheDocument();
+  });
+
+  it('renders Stage 3: Learning Plan section', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Stage 3: Plan Learning Experiences and Instruction')).toBeInTheDocument();
+  });
+
+  it('renders learning sequence overview', () => {
+    render(<UnitLessonPlan lesson={mockLesson} />);
+
+    expect(screen.getByText('Learning Sequence Overview')).toBeInTheDocument();
+    expect(screen.getByText('Foundation Week')).toBeInTheDocument();
+    expect(screen.getByText('Week 1')).toBeInTheDocument();
+  });
+
+  it('handles lesson with minimal metadata', () => {
+    const minimalLesson: Lesson = {
+      ...mockLesson,
+      metadata: null
+    };
+
+    render(<UnitLessonPlan lesson={minimalLesson} />);
+
+    // Should still render basic structure
+    expect(screen.getByText('Unit 1: Balance by Design')).toBeInTheDocument();
+    expect(screen.getByText('Stage 1: Identify Desired Results')).toBeInTheDocument();
+  });
+
+  it('renders daily lessons when provided', () => {
+    const dailyLessons = [
+      {
+        day: 1,
+        title: 'Introduction',
+        focus: 'Core concepts',
+        duration: '45 min',
+        activities: [
+          {
+            name: 'Hook Activity',
+            duration: '10 min',
+            description: 'Engage students',
+            details: ['Show video', 'Discuss']
+          }
+        ],
+        materials: ['Projector', 'Handouts']
+      }
+    ];
+
+    render(<UnitLessonPlan lesson={mockLesson} dailyLessons={dailyLessons} />);
+
+    expect(screen.getByText('Detailed Daily Plans')).toBeInTheDocument();
+    expect(screen.getByText('Day 1: Introduction')).toBeInTheDocument();
+    expect(screen.getByText(/Core concepts/)).toBeInTheDocument();
+  });
+
+  it('renders assessment strategies when provided', () => {
+    const strategies = [
+      {
+        title: 'Formative Assessment',
+        strategies: ['Exit tickets', 'Quick checks']
+      }
+    ];
+
+    render(<UnitLessonPlan lesson={mockLesson} assessmentStrategies={strategies} />);
+
+    expect(screen.getByText('Assessment Strategies & Differentiation')).toBeInTheDocument();
+    expect(screen.getByText('Formative Assessment')).toBeInTheDocument();
+    expect(screen.getByText('Exit tickets')).toBeInTheDocument();
+  });
+
+  it('renders differentiation supports when provided', () => {
+    const differentiation = [
+      {
+        title: 'ELL Support',
+        strategies: ['Visual aids', 'Translation support']
+      }
+    ];
+
+    render(<UnitLessonPlan lesson={mockLesson} differentiation={differentiation} />);
+
+    expect(screen.getByText('Differentiation Support')).toBeInTheDocument();
+    expect(screen.getByText('ELL Support')).toBeInTheDocument();
+    expect(screen.getByText('Visual aids')).toBeInTheDocument();
+  });
+
+  it('renders reflection section when questions provided', () => {
+    const questions = ['What worked well?', 'What needs improvement?'];
+
+    render(<UnitLessonPlan lesson={mockLesson} reflectionQuestions={questions} />);
+
+    expect(screen.getByText('Reflection & Continuous Improvement')).toBeInTheDocument();
+    expect(screen.getByText('Post-Unit Reflection Questions')).toBeInTheDocument();
+    expect(screen.getByText('What worked well?')).toBeInTheDocument();
+  });
+});

--- a/components/teacher/UnitLessonPlan.tsx
+++ b/components/teacher/UnitLessonPlan.tsx
@@ -1,0 +1,740 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  Target,
+  CheckCircle,
+  BookOpen,
+  Clock,
+  Users,
+  AlertTriangle,
+  Lightbulb,
+  Info,
+  FileText,
+  Settings,
+  MessageSquare,
+  Code,
+  Flag,
+  TrendingUp,
+  Briefcase,
+  GraduationCap
+} from "lucide-react"
+import { type Lesson } from '@/lib/db/schema/validators';
+
+interface DailyLessonActivity {
+  name: string;
+  duration: string;
+  description: string;
+  details: string[];
+  callout?: {
+    type: 'tip' | 'important' | 'definition' | 'example' | 'reflection' | 'technical' | 'checkpoint' | 'strategy' | 'professional' | 'assessment';
+    title: string;
+    content: string;
+    items?: string[];
+  };
+  video?: {
+    title: string;
+    duration: string;
+    description: string;
+    youtubeId?: string;
+  };
+  interactiveActivities?: Array<{
+    type: 'multiple-choice' | 'drag-drop' | 'turn-talk' | 'think-pair-share';
+    title: string;
+    description: string;
+    duration: string;
+  }>;
+}
+
+interface DailyLesson {
+  day: number;
+  title: string;
+  focus: string;
+  duration: string;
+  activities: DailyLessonActivity[];
+  materials: string[];
+}
+
+interface AssessmentStrategy {
+  title: string;
+  strategies: string[];
+}
+
+interface DifferentiationSupport {
+  title: string;
+  strategies: string[];
+}
+
+interface ResourceCategory {
+  title: string;
+  items: Array<{
+    name: string;
+    link?: string;
+  }>;
+}
+
+interface UnitLessonPlanProps {
+  lesson: Lesson;
+  gradeLevel?: string;
+  course?: string;
+  dailyLessons?: DailyLesson[];
+  assessmentStrategies?: AssessmentStrategy[];
+  differentiation?: DifferentiationSupport[];
+  resources?: ResourceCategory[];
+  reflectionQuestions?: string[];
+  dataCollection?: string[];
+  nextUnitPrep?: string[];
+}
+
+export function UnitLessonPlan({
+  lesson,
+  gradeLevel = "9-12",
+  course = "Business Operations",
+  dailyLessons = [],
+  assessmentStrategies = [],
+  differentiation = [],
+  resources = [],
+  reflectionQuestions = [],
+  dataCollection = [],
+  nextUnitPrep = []
+}: UnitLessonPlanProps) {
+  const unitContent = lesson.metadata?.unitContent;
+  const drivingQuestion = unitContent?.drivingQuestion?.question;
+  const durationLabel = lesson.metadata?.durationLabel || "3-4 weeks";
+
+  // Extract objectives
+  const enduringUnderstandings = unitContent?.objectives?.content || [];
+  const contentKnowledge = unitContent?.objectives?.content || [];
+  const technicalKnowledge = unitContent?.objectives?.skills || [];
+  const contentSkills = enduringUnderstandings;
+  const technicalSkills = unitContent?.objectives?.skills || [];
+
+  // Extract assessment data
+  const performanceTask = unitContent?.assessment?.performanceTask;
+  const milestones = unitContent?.assessment?.milestones || [];
+  const rubric = unitContent?.assessment?.rubric || [];
+
+  // Extract learning sequence
+  const learningPhases = unitContent?.learningSequence?.weeks?.map(week => ({
+    title: week.title,
+    description: week.description,
+    days: `Week ${week.weekNumber}`
+  })) || [];
+
+  return (
+    <div className="max-w-6xl mx-auto p-8">
+      {/* Header */}
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold mb-4">
+          Unit {lesson.unitNumber}: {lesson.title}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-4">
+          {lesson.description}
+        </p>
+
+        {/* Unit Meta */}
+        <div className="flex flex-wrap gap-4 p-4 bg-slate-50 dark:bg-slate-950/20 rounded-lg">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            <span><strong>Duration:</strong> {durationLabel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span><strong>Grade Level:</strong> {gradeLevel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4" />
+            <span><strong>Course:</strong> {course}</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Stage 1: Desired Results */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6 flex items-center gap-2">
+          <Target className="h-6 w-6 text-red-600" />
+          Stage 1: Identify Desired Results
+        </h2>
+
+        {/* Essential Question */}
+        {drivingQuestion && (
+          <Card className="mb-6 border-purple-200 bg-purple-50 dark:bg-purple-950/10">
+            <CardHeader>
+              <CardTitle className="text-lg text-purple-800 dark:text-purple-200">
+                Essential Question
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-purple-700 dark:text-purple-300 italic text-lg">
+                {drivingQuestion}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Objectives */}
+        <div className="space-y-6">
+          {/* Enduring Understandings */}
+          {enduringUnderstandings.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Enduring Understandings</CardTitle>
+                <CardDescription>Students will understand that...</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2">
+                  {enduringUnderstandings.map((understanding, index) => (
+                    <li key={index} className="flex items-start gap-2">
+                      <span className="text-primary mt-1">•</span>
+                      <span>{understanding}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Knowledge & Skills Grid */}
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Students will know...</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {contentKnowledge.length > 0 && (
+                  <div>
+                    <h4 className="font-medium mb-2 text-primary">Accounting Content</h4>
+                    <ul className="space-y-1 text-sm">
+                      {contentKnowledge.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-muted-foreground mt-1">•</span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {technicalKnowledge.length > 0 && (
+                  <div>
+                    <h4 className="font-medium mb-2 text-primary">Excel Technical Skills</h4>
+                    <ul className="space-y-1 text-sm">
+                      {technicalKnowledge.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-muted-foreground mt-1">•</span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Students will be able to...</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {contentSkills.length > 0 && (
+                  <div>
+                    <h4 className="font-medium mb-2 text-primary">Accounting Skills</h4>
+                    <ul className="space-y-1 text-sm">
+                      {contentSkills.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-muted-foreground mt-1">•</span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {technicalSkills.length > 0 && (
+                  <div>
+                    <h4 className="font-medium mb-2 text-primary">Excel Skills</h4>
+                    <ul className="space-y-1 text-sm">
+                      {technicalSkills.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-muted-foreground mt-1">•</span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Stage 2: Assessment Evidence */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6 flex items-center gap-2">
+          <CheckCircle className="h-6 w-6 text-blue-600" />
+          Stage 2: Determine Acceptable Evidence
+        </h2>
+
+        {/* Performance Task */}
+        {performanceTask && (
+          <Card className="mb-6 border-blue-200 bg-blue-50 dark:bg-blue-950/10">
+            <CardHeader>
+              <CardTitle className="text-lg text-blue-800 dark:text-blue-200">
+                Performance Task (Summative Assessment)
+              </CardTitle>
+              <CardDescription className="text-blue-700 dark:text-blue-300 font-medium">
+                {performanceTask.title}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-blue-700 dark:text-blue-300">
+              <p className="mb-4">{performanceTask.description}</p>
+
+              {performanceTask.requirements && performanceTask.requirements.length > 0 && (
+                <div className="mb-4">
+                  <h4 className="font-semibold mb-2">Performance Requirements:</h4>
+                  <ul className="space-y-1">
+                    {performanceTask.requirements.map((req, index) => (
+                      <li key={index} className="flex items-start gap-2">
+                        <span className="mt-1">•</span>
+                        <span>{req}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {performanceTask.context && (
+                <div>
+                  <h4 className="font-semibold mb-2">Authentic Context:</h4>
+                  <p>{performanceTask.context}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Milestones */}
+        {milestones.length > 0 && (
+          <div className="mb-6">
+            <h3 className="text-xl font-semibold mb-4">Milestone Assessments (Formative)</h3>
+            <div className="grid gap-4 md:grid-cols-3">
+              {milestones.map((milestone, index) => (
+                <Card key={index}>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      Milestone {index + 1}
+                      <Badge variant="secondary">Day {milestone.day}</Badge>
+                    </CardTitle>
+                    <CardDescription className="font-medium">
+                      {milestone.title}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-1 text-sm">
+                      {milestone.criteria.map((criterion, critIndex) => (
+                        <li key={critIndex} className="flex items-start gap-2">
+                          <span className="text-muted-foreground mt-1">•</span>
+                          <span>{criterion}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Rubric */}
+        {rubric.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Success Criteria & Rubric</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse border border-gray-300 dark:border-gray-600 text-sm">
+                  <thead>
+                    <tr className="bg-gray-100 dark:bg-gray-800">
+                      <th className="border border-gray-300 dark:border-gray-600 p-3 text-left font-medium">Criteria</th>
+                      <th className="border border-gray-300 dark:border-gray-600 p-3 text-left font-medium">Weight</th>
+                      <th className="border border-gray-300 dark:border-gray-600 p-3 text-left font-medium">Exemplary (A)</th>
+                      <th className="border border-gray-300 dark:border-gray-600 p-3 text-left font-medium">Proficient (B-C)</th>
+                      <th className="border border-gray-300 dark:border-gray-600 p-3 text-left font-medium">Developing (D)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rubric.map((criteria, index) => (
+                      <tr key={index} className={index % 2 === 0 ? "bg-gray-50 dark:bg-gray-900/50" : ""}>
+                        <td className="border border-gray-300 dark:border-gray-600 p-3 font-medium">
+                          {criteria.name}
+                        </td>
+                        <td className="border border-gray-300 dark:border-gray-600 p-3">
+                          {criteria.weight}
+                        </td>
+                        <td className="border border-gray-300 dark:border-gray-600 p-3">
+                          {criteria.exemplary}
+                        </td>
+                        <td className="border border-gray-300 dark:border-gray-600 p-3">
+                          {criteria.proficient}
+                        </td>
+                        <td className="border border-gray-300 dark:border-gray-600 p-3">
+                          {criteria.developing}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      {/* Stage 3: Learning Plan */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6 flex items-center gap-2">
+          <BookOpen className="h-6 w-6 text-green-600" />
+          Stage 3: Plan Learning Experiences and Instruction
+        </h2>
+
+        {/* Learning Sequence Overview */}
+        {learningPhases.length > 0 && (
+          <div className="mb-8">
+            <h3 className="text-xl font-semibold mb-4">Learning Sequence Overview</h3>
+            <div className="grid md:grid-cols-3 gap-4">
+              {learningPhases.map((phase, index) => (
+                <Card key={index} className="text-center border-green-200 bg-green-50 dark:bg-green-950/10">
+                  <CardContent className="pt-6">
+                    <h4 className="font-semibold text-green-800 dark:text-green-200 mb-2">
+                      {phase.title}
+                    </h4>
+                    <Badge variant="secondary" className="mb-3">{phase.days}</Badge>
+                    <p className="text-green-700 dark:text-green-300 text-sm">
+                      {phase.description}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Daily Plans */}
+        {dailyLessons.length > 0 && (
+          <div className="space-y-8">
+            <h3 className="text-xl font-semibold">Detailed Daily Plans</h3>
+
+            {dailyLessons.map((dailyLesson, index) => (
+              <DailyLessonCard key={index} lesson={dailyLesson} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Assessment Strategies & Differentiation */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6">Assessment Strategies & Differentiation</h2>
+
+        <div className="grid md:grid-cols-2 gap-8">
+          {/* Assessment Strategies */}
+          {assessmentStrategies.length > 0 && (
+            <div className="space-y-6">
+              {assessmentStrategies.map((strategy, index) => (
+                <Card key={index}>
+                  <CardHeader>
+                    <CardTitle className="text-lg">{strategy.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {strategy.strategies.map((item, itemIndex) => (
+                        <li key={itemIndex} className="flex items-start gap-2">
+                          <span className="text-primary mt-1">•</span>
+                          <span className="text-sm">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {/* Differentiation */}
+          {differentiation.length > 0 && (
+            <div className="space-y-6">
+              <h3 className="text-xl font-semibold">Differentiation Support</h3>
+              {differentiation.map((support, index) => (
+                <Card key={index}>
+                  <CardHeader>
+                    <CardTitle className="text-lg">{support.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {support.strategies.map((strategy, stratIndex) => (
+                        <li key={stratIndex} className="flex items-start gap-2">
+                          <span className="text-primary mt-1">•</span>
+                          <span className="text-sm">{strategy}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Resources */}
+      {resources.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-6">Required Resources & Materials</h2>
+
+          <div className="grid gap-6 md:grid-cols-3">
+            {resources.map((resource, index) => (
+              <Card key={index} className="bg-slate-50 dark:bg-slate-950/20">
+                <CardHeader>
+                  <CardTitle className="text-lg flex items-center gap-2">
+                    <Settings className="h-5 w-5" />
+                    {resource.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2">
+                    {resource.items.map((item, itemIndex) => (
+                      <li key={itemIndex} className="text-sm">
+                        {item.link ? (
+                          <a href={item.link} className="text-primary hover:underline">
+                            {item.name}
+                          </a>
+                        ) : (
+                          <span>{item.name}</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Reflection */}
+      {(reflectionQuestions.length > 0 || dataCollection.length > 0 || nextUnitPrep.length > 0) && (
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-6">Reflection & Continuous Improvement</h2>
+
+          <div className="space-y-6">
+            {reflectionQuestions.length > 0 && (
+              <Card className="border-amber-200 bg-amber-50 dark:bg-amber-950/10">
+                <CardHeader>
+                  <CardTitle className="text-lg text-amber-800 dark:text-amber-200">
+                    Post-Unit Reflection Questions
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2 text-amber-700 dark:text-amber-300">
+                    {reflectionQuestions.map((question, index) => (
+                      <li key={index} className="flex items-start gap-2">
+                        <span className="mt-1">•</span>
+                        <span>{question}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            )}
+
+            <div className="grid md:grid-cols-2 gap-6">
+              {dataCollection.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg">Data Collection for Improvement</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {dataCollection.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-primary mt-1">•</span>
+                          <span className="text-sm">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              )}
+
+              {nextUnitPrep.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg">Preparation for Next Unit</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {nextUnitPrep.map((item, index) => (
+                        <li key={index} className="flex items-start gap-2">
+                          <span className="text-primary mt-1">•</span>
+                          <span className="text-sm">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+// Separate component for daily lesson cards
+function DailyLessonCard({ lesson }: { lesson: DailyLesson }) {
+  const getCalloutIcon = (type: string) => {
+    switch (type) {
+      case 'tip': return <Lightbulb className="h-5 w-5" />
+      case 'important': return <AlertTriangle className="h-5 w-5" />
+      case 'definition': return <Info className="h-5 w-5" />
+      case 'example': return <FileText className="h-5 w-5" />
+      case 'reflection': return <MessageSquare className="h-5 w-5" />
+      case 'technical': return <Code className="h-5 w-5" />
+      case 'checkpoint': return <Flag className="h-5 w-5" />
+      case 'strategy': return <TrendingUp className="h-5 w-5" />
+      case 'professional': return <Briefcase className="h-5 w-5" />
+      case 'assessment': return <GraduationCap className="h-5 w-5" />
+      default: return <Info className="h-5 w-5" />
+    }
+  }
+
+  const getCalloutColors = (type: string) => {
+    switch (type) {
+      case 'tip': return 'border-blue-200 bg-blue-50 dark:bg-blue-950/10 text-blue-800 dark:text-blue-200'
+      case 'important': return 'border-red-200 bg-red-50 dark:bg-red-950/10 text-red-800 dark:text-red-200'
+      case 'definition': return 'border-green-200 bg-green-50 dark:bg-green-950/10 text-green-800 dark:text-green-200'
+      case 'example': return 'border-purple-200 bg-purple-50 dark:bg-purple-950/10 text-purple-800 dark:text-purple-200'
+      case 'reflection': return 'border-amber-200 bg-amber-50 dark:bg-amber-950/10 text-amber-800 dark:text-amber-200'
+      case 'technical': return 'border-slate-200 bg-slate-50 dark:bg-slate-950/10 text-slate-800 dark:text-slate-200'
+      case 'checkpoint': return 'border-orange-200 bg-orange-50 dark:bg-orange-950/10 text-orange-800 dark:text-orange-200'
+      case 'strategy': return 'border-teal-200 bg-teal-50 dark:bg-teal-950/10 text-teal-800 dark:text-teal-200'
+      case 'professional': return 'border-indigo-200 bg-indigo-50 dark:bg-indigo-950/10 text-indigo-800 dark:text-indigo-200'
+      case 'assessment': return 'border-cyan-200 bg-cyan-50 dark:bg-cyan-950/10 text-cyan-800 dark:text-cyan-200'
+      default: return 'border-gray-200 bg-gray-50 dark:bg-gray-950/10 text-gray-800 dark:text-gray-200'
+    }
+  }
+
+  return (
+    <Card className="border-l-4 border-l-primary">
+      <CardHeader>
+        <CardTitle className="text-xl">Day {lesson.day}: {lesson.title}</CardTitle>
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <span><strong>Focus:</strong> {lesson.focus}</span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-4 w-4" />
+            {lesson.duration}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {lesson.activities.map((activity, index) => (
+          <div key={index}>
+            <h4 className="text-lg font-medium text-primary border-b border-gray-200 pb-2 mb-3">
+              {activity.name} ({activity.duration})
+            </h4>
+
+            <p className="mb-3">{activity.description}</p>
+
+            {activity.video && (
+              <Card className="mb-4 border-purple-200 bg-purple-50 dark:bg-purple-950/10">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2 text-purple-800 dark:text-purple-200">
+                    <FileText className="h-5 w-5" />
+                    {activity.video.title} ({activity.video.duration})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-purple-700 dark:text-purple-300">{activity.video.description}</p>
+                  {activity.video.youtubeId && (
+                    <p className="text-sm text-purple-600 dark:text-purple-400 mt-2">
+                      YouTube ID: {activity.video.youtubeId}
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {activity.interactiveActivities && (
+              <div className="mb-4 space-y-2">
+                <h5 className="font-medium text-primary">Interactive Activities:</h5>
+                {activity.interactiveActivities.map((interactiveActivity, intIndex) => (
+                  <Card key={intIndex} className="border-orange-200 bg-orange-50 dark:bg-orange-950/10">
+                    <CardContent className="pt-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="font-medium text-orange-800 dark:text-orange-200">
+                          {interactiveActivity.title}
+                        </span>
+                        <Badge variant="outline" className="text-orange-700 dark:text-orange-300">
+                          {interactiveActivity.duration}
+                        </Badge>
+                      </div>
+                      <p className="text-orange-700 dark:text-orange-300 text-sm">
+                        <strong>{interactiveActivity.type}:</strong> {interactiveActivity.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {activity.callout && (
+              <Card className={`mb-4 ${getCalloutColors(activity.callout.type)}`}>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    {getCalloutIcon(activity.callout.type)}
+                    {activity.callout.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-2">{activity.callout.content}</p>
+                  {activity.callout.items && (
+                    <ul className="space-y-1">
+                      {activity.callout.items.map((item, itemIndex) => (
+                        <li key={itemIndex} className="flex items-start gap-2">
+                          <span className="mt-1">•</span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            <ul className="space-y-2">
+              {activity.details.map((detail, detailIndex) => (
+                <li key={detailIndex} className="flex items-start gap-2">
+                  <span className="text-primary mt-1">•</span>
+                  <span>{detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+
+        {lesson.materials.length > 0 && (
+          <div>
+            <h4 className="text-lg font-medium text-primary mb-3">Materials Needed</h4>
+            <ul className="space-y-1">
+              {lesson.materials.map((material, index) => (
+                <li key={index} className="flex items-start gap-2">
+                  <span className="text-muted-foreground mt-1">•</span>
+                  <span className="text-sm">{material}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/teacher/UnitOverview.test.tsx
+++ b/components/teacher/UnitOverview.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UnitOverview } from './UnitOverview';
+import { type Lesson } from '@/lib/db/schema/validators';
+
+describe('UnitOverview', () => {
+  const mockLesson: Lesson = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    unitNumber: 1,
+    title: 'Balance by Design',
+    slug: 'balance-by-design',
+    description: 'Learn the fundamental accounting equation and how assets, liabilities, and equity work together.',
+    learningObjectives: [
+      'Understand the accounting equation',
+      'Identify assets, liabilities, and equity',
+      'Apply the accounting equation to real-world scenarios'
+    ],
+    orderIndex: 1,
+    metadata: {
+      duration: 120,
+      durationLabel: '3-4 weeks',
+      difficulty: 'beginner',
+      tags: ['accounting', 'fundamentals'],
+      unitContent: {
+        drivingQuestion: {
+          question: 'How can a business track what it owns, what it owes, and what belongs to its owners?',
+          context: 'Students explore the fundamental accounting equation through a real business scenario.'
+        },
+        objectives: {
+          content: [
+            'Financial statement analysis',
+            'Business decision-making',
+            'Professional communication'
+          ],
+          skills: [
+            'Excel table formatting',
+            'Excel SUMIF formulas',
+            'Excel conditional formatting',
+            'Data visualization techniques'
+          ],
+          deliverables: [
+            'Complete financial statement',
+            'Professional presentation'
+          ]
+        },
+        assessment: {
+          performanceTask: {
+            title: 'Create a Balance Sheet',
+            description: 'Students create a complete balance sheet for a business scenario',
+            requirements: [
+              'Accurate asset classification',
+              'Proper liability categorization',
+              'Correct equity calculation'
+            ],
+            context: 'Real-world business scenario'
+          },
+          milestones: [
+            {
+              id: 'milestone-1',
+              day: 5,
+              title: 'Asset Identification',
+              description: 'Students identify and classify business assets',
+              criteria: ['Correctly classify 5 assets', 'Explain asset types']
+            },
+            {
+              id: 'milestone-2',
+              day: 10,
+              title: 'Complete Equation Application',
+              description: 'Apply accounting equation to scenarios',
+              criteria: ['Balance equation correctly', 'Show all work']
+            }
+          ],
+          rubric: []
+        },
+        learningSequence: {
+          weeks: []
+        },
+        prerequisites: {
+          knowledge: ['Basic math'],
+          technology: ['Excel'],
+          resources: []
+        }
+      }
+    },
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+  };
+
+  it('renders unit title and number', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Unit 1: Balance by Design')).toBeInTheDocument();
+  });
+
+  it('renders unit description', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText(/Learn the fundamental accounting equation/)).toBeInTheDocument();
+  });
+
+  it('renders unit meta information', () => {
+    render(<UnitOverview lesson={mockLesson} gradeLevel="9-12" course="Business Operations" />);
+
+    expect(screen.getByText(/3-4 weeks/)).toBeInTheDocument();
+    expect(screen.getByText(/9-12/)).toBeInTheDocument();
+    expect(screen.getByText(/Business Operations/)).toBeInTheDocument();
+  });
+
+  it('renders essential question when available', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Essential Question')).toBeInTheDocument();
+    expect(screen.getByText(/How can a business track what it owns/)).toBeInTheDocument();
+  });
+
+  it('renders learning targets from learning objectives', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Learning Targets')).toBeInTheDocument();
+    expect(screen.getByText('Understand the accounting equation')).toBeInTheDocument();
+    expect(screen.getByText('Identify assets, liabilities, and equity')).toBeInTheDocument();
+  });
+
+  it('renders Excel skills when available', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Excel Skills')).toBeInTheDocument();
+    expect(screen.getByText(/Excel table formatting/)).toBeInTheDocument();
+    expect(screen.getByText(/Excel SUMIF formulas/)).toBeInTheDocument();
+  });
+
+  it('renders business skills from objectives', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Business Skills')).toBeInTheDocument();
+    expect(screen.getByText('Financial statement analysis')).toBeInTheDocument();
+    expect(screen.getByText('Business decision-making')).toBeInTheDocument();
+  });
+
+  it('renders key assessments from performance task and milestones', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    expect(screen.getByText('Key Assessments')).toBeInTheDocument();
+    expect(screen.getByText('Create a Balance Sheet')).toBeInTheDocument();
+    expect(screen.getByText(/Asset Identification \(Day 5\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Complete Equation Application \(Day 10\)/)).toBeInTheDocument();
+  });
+
+  it('renders capstone connection', () => {
+    const customCapstone = 'This unit provides the foundation for creating complete financial models in the capstone project.';
+    render(<UnitOverview lesson={mockLesson} capstoneConnection={customCapstone} />);
+
+    expect(screen.getByText('Connection to Capstone Project')).toBeInTheDocument();
+    expect(screen.getByText(customCapstone)).toBeInTheDocument();
+  });
+
+  it('handles lesson without unit content gracefully', () => {
+    const minimalLesson: Lesson = {
+      ...mockLesson,
+      metadata: null,
+      learningObjectives: null
+    };
+
+    render(<UnitOverview lesson={minimalLesson} />);
+
+    // Should still render basic information
+    expect(screen.getByText('Unit 1: Balance by Design')).toBeInTheDocument();
+    expect(screen.getByText(/Learn the fundamental accounting equation/)).toBeInTheDocument();
+  });
+
+  it('uses default values for optional props', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    // Default grade level and course should be rendered
+    expect(screen.getByText(/9-12/)).toBeInTheDocument();
+    expect(screen.getByText(/Business Operations/)).toBeInTheDocument();
+  });
+
+  it('renders correct number of learning targets', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    const learningTargets = mockLesson.learningObjectives;
+    expect(learningTargets).toHaveLength(3);
+
+    learningTargets?.forEach(target => {
+      expect(screen.getByText(target)).toBeInTheDocument();
+    });
+  });
+
+  it('filters Excel skills correctly', () => {
+    render(<UnitOverview lesson={mockLesson} />);
+
+    // Should show Excel-related skills
+    expect(screen.getByText(/Excel table formatting/)).toBeInTheDocument();
+    expect(screen.getByText(/Excel SUMIF formulas/)).toBeInTheDocument();
+
+    // Should not show non-Excel skills in Excel section
+    const excelSkillsSection = screen.getByText('Excel Skills').closest('div');
+    expect(excelSkillsSection).not.toHaveTextContent('Financial statement analysis');
+  });
+});

--- a/components/teacher/UnitOverview.tsx
+++ b/components/teacher/UnitOverview.tsx
@@ -1,0 +1,222 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  Target,
+  CheckCircle,
+  BookOpen,
+  Clock,
+  Users,
+  FileText,
+  TrendingUp
+} from "lucide-react"
+import { type Lesson } from '@/lib/db/schema/validators';
+
+interface UnitOverviewProps {
+  lesson: Lesson;
+  gradeLevel?: string;
+  course?: string;
+  capstoneConnection?: string;
+}
+
+export function UnitOverview({ lesson, gradeLevel = "9-12", course = "Business Operations", capstoneConnection }: UnitOverviewProps) {
+  // Extract unit content from lesson metadata
+  const unitContent = lesson.metadata?.unitContent;
+  const drivingQuestion = unitContent?.drivingQuestion?.question;
+  const durationLabel = lesson.metadata?.durationLabel || "3-4 weeks";
+
+  // Map learning objectives to learning targets
+  const learningTargets = lesson.learningObjectives || [];
+
+  // Extract skills from objectives
+  const excelSkills = unitContent?.objectives?.skills?.filter(skill =>
+    skill.toLowerCase().includes('excel') ||
+    skill.toLowerCase().includes('formula') ||
+    skill.toLowerCase().includes('spreadsheet')
+  ) || [];
+
+  const businessSkills = unitContent?.objectives?.content || [];
+
+  // Extract key assessments from assessment data
+  const keyAssessments: string[] = [];
+  if (unitContent?.assessment?.performanceTask) {
+    keyAssessments.push(unitContent.assessment.performanceTask.title);
+  }
+  if (unitContent?.assessment?.milestones) {
+    unitContent.assessment.milestones.forEach(milestone => {
+      keyAssessments.push(`${milestone.title} (Day ${milestone.day})`);
+    });
+  }
+
+  // Use provided capstone connection or build from unit content
+  const capstoneText = capstoneConnection ||
+    unitContent?.introduction?.projectOverview?.deliverable ||
+    "This unit builds essential skills for the semester capstone project.";
+
+  return (
+    <div className="max-w-4xl mx-auto p-8">
+      {/* Header */}
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold mb-4">
+          Unit {lesson.unitNumber}: {lesson.title}
+        </h1>
+        <p className="text-lg text-muted-foreground mb-4">
+          {lesson.description}
+        </p>
+
+        {/* Unit Meta */}
+        <div className="flex flex-wrap gap-4 p-4 bg-slate-50 dark:bg-slate-950/20 rounded-lg">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            <span><strong>Duration:</strong> {durationLabel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span><strong>Grade Level:</strong> {gradeLevel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4" />
+            <span><strong>Course:</strong> {course}</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Essential Question */}
+      {drivingQuestion && (
+        <section className="mb-8">
+          <Card className="border-purple-200 bg-purple-50 dark:bg-purple-950/10">
+            <CardHeader>
+              <CardTitle className="text-lg text-purple-800 dark:text-purple-200 flex items-center gap-2">
+                <Target className="h-5 w-5" />
+                Essential Question
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-purple-700 dark:text-purple-300 italic text-lg">
+                {drivingQuestion}
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+      )}
+
+      {/* Learning Targets */}
+      {learningTargets.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-6 flex items-center gap-2">
+            <Target className="h-6 w-6 text-red-600" />
+            Learning Targets
+          </h2>
+
+          <Card className="border-red-200 bg-red-50 dark:bg-red-950/10">
+            <CardHeader>
+              <CardTitle className="text-lg text-red-800 dark:text-red-200">
+                Students will be able to...
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2">
+                {learningTargets.map((target, index) => (
+                  <li key={index} className="flex items-start gap-2 text-red-700 dark:text-red-300">
+                    <span className="mt-1">•</span>
+                    <span>{target}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </section>
+      )}
+
+      {/* Skills & Assessment Overview */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6 flex items-center gap-2">
+          <CheckCircle className="h-6 w-6 text-blue-600" />
+          Skills & Assessment Overview
+        </h2>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-6">
+          {excelSkills.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg flex items-center gap-2">
+                  <BookOpen className="h-5 w-5 text-green-600" />
+                  Excel Skills
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2">
+                  {excelSkills.map((skill, index) => (
+                    <li key={index} className="flex items-start gap-2">
+                      <span className="text-green-600 mt-1">•</span>
+                      <span className="text-sm">{skill}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+
+          {businessSkills.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-blue-600" />
+                  Business Skills
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2">
+                  {businessSkills.map((skill, index) => (
+                    <li key={index} className="flex items-start gap-2">
+                      <span className="text-blue-600 mt-1">•</span>
+                      <span className="text-sm">{skill}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {keyAssessments.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg flex items-center gap-2">
+                <FileText className="h-5 w-5 text-orange-600" />
+                Key Assessments
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4">
+                {keyAssessments.map((assessment, index) => (
+                  <div key={index} className="flex items-center gap-3 p-3 bg-orange-50 dark:bg-orange-950/10 rounded-lg">
+                    <Badge variant="secondary">Assessment {index + 1}</Badge>
+                    <span className="text-orange-700 dark:text-orange-300">{assessment}</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      {/* Capstone Connection */}
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-6">Connection to Capstone Project</h2>
+
+        <Card className="border-green-200 bg-green-50 dark:bg-green-950/10">
+          <CardHeader>
+            <CardTitle className="text-lg text-green-800 dark:text-green-200">
+              How This Unit Builds Toward Semester 2
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-green-700 dark:text-green-300">
+              {capstoneText}
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Migrated three teacher-specific components (Category 11) from v1 to v2 with database-shaped props:

- **UnitOverview**: Teacher unit view with learning targets, skills, and assessments
- **UnitLessonPlan**: Complete backwards-designed lesson planning (Stage 1-3) following UbD framework
- **TeacherLessonPlan**: Individual lesson plans with 6-phase structure and teacher guidance

## Changes
- ✅ All three components migrated from v1 to v2
- ✅ Components accept `Lesson` and `Phase` types from drizzle-zod validators
- ✅ Mapped v1 hardcoded data to database-shaped props
- ✅ Comprehensive test coverage: 48 tests passing
- ✅ TypeScript compilation successful
- ✅ No linting errors

## Database Integration
Components now use database-shaped props:
- Lesson plan data from `lessons.metadata.unitContent`
- Pedagogical content from `unitContent.objectives`, `assessment`, and `learningSequence`
- Phase content from `phases.contentBlocks` and `phases.metadata`

## Test Plan
- [x] All unit tests passing (48/48)
- [x] Components render with database props
- [x] Teacher views display lesson data correctly
- [x] Pedagogical content displays correctly
- [x] Differentiation info accessible
- [x] No TypeScript errors
- [x] Linting passes

## Issue
Closes #37

Part of Epic #41 (V1 Component Migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)