### PR TITLE
feat: migrate accessibility & support components (#38)

### DIFF
--- a/components/student/AccessibilityToolbar.test.tsx
+++ b/components/student/AccessibilityToolbar.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { AccessibilityToolbar } from './AccessibilityToolbar';
+import type { AccessibilityPreferences } from '@/lib/db/schema/profiles';
+
+describe('AccessibilityToolbar', () => {
+  const defaultPreferences: AccessibilityPreferences = {
+    language: 'en',
+    fontSize: 'medium',
+    highContrast: false,
+    readingLevel: 'intermediate',
+    showVocabulary: false,
+  };
+
+  it('renders with default preferences', () => {
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByRole('toolbar', { name: /accessibility settings/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /switch to english/i, pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /medium font size/i, pressed: true })).toBeInTheDocument();
+  });
+
+  it('calls onPreferencesChange when language is changed', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const chineseButton = screen.getByRole('button', { name: /switch to chinese/i });
+    await user.click(chineseButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ language: 'zh' });
+  });
+
+  it('calls onPreferencesChange when font size is changed', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const largeButton = screen.getByRole('button', { name: /large font size/i });
+    await user.click(largeButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ fontSize: 'large' });
+  });
+
+  it('calls onPreferencesChange when high contrast is toggled', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const contrastButton = screen.getByRole('button', { name: /enable high contrast/i });
+    await user.click(contrastButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ highContrast: true });
+  });
+
+  it('calls onPreferencesChange when reading level is changed', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const select = screen.getByRole('combobox', { name: /reading level/i });
+    await user.selectOptions(select, 'advanced');
+
+    expect(mockOnChange).toHaveBeenCalledWith({ readingLevel: 'advanced' });
+  });
+
+  it('calls onPreferencesChange when vocabulary is toggled', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const vocabButton = screen.getByRole('button', { name: /show vocabulary/i });
+    await user.click(vocabButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ showVocabulary: true });
+  });
+
+  it('applies high contrast styles when enabled', () => {
+    const mockOnChange = vi.fn();
+    const highContrastPreferences: AccessibilityPreferences = {
+      ...defaultPreferences,
+      highContrast: true,
+    };
+
+    const { container } = render(
+      <AccessibilityToolbar
+        preferences={highContrastPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    const card = container.querySelector('.bg-gray-900');
+    expect(card).toBeInTheDocument();
+  });
+
+  it('displays correct reading level options in English', () => {
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByRole('option', { name: 'Basic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Intermediate' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Advanced' })).toBeInTheDocument();
+  });
+
+  it('displays correct reading level options in Chinese', () => {
+    const mockOnChange = vi.fn();
+    const chinesePreferences: AccessibilityPreferences = {
+      ...defaultPreferences,
+      language: 'zh',
+    };
+
+    render(
+      <AccessibilityToolbar
+        preferences={chinesePreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByRole('option', { name: '基础' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '中级' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '高级' })).toBeInTheDocument();
+  });
+
+  it('has correct ARIA attributes for accessibility', () => {
+    const mockOnChange = vi.fn();
+    render(
+      <AccessibilityToolbar
+        preferences={defaultPreferences}
+        onPreferencesChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByRole('group', { name: /language selection/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /font size selection/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /switch to english/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/components/student/AccessibilityToolbar.tsx
+++ b/components/student/AccessibilityToolbar.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import React from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import {
+  Globe,
+  Type,
+  Eye,
+  BookOpen,
+  Palette
+} from 'lucide-react'
+import type { AccessibilityPreferences } from '@/lib/db/schema/profiles'
+
+interface AccessibilityToolbarProps {
+  preferences: AccessibilityPreferences
+  onPreferencesChange: (preferences: Partial<AccessibilityPreferences>) => void
+  className?: string
+}
+
+export function AccessibilityToolbar({
+  preferences,
+  onPreferencesChange,
+  className = ''
+}: AccessibilityToolbarProps) {
+  const handleLanguageChange = (language: 'en' | 'zh') => {
+    onPreferencesChange({ language })
+  }
+
+  const handleFontSizeChange = (fontSize: 'small' | 'medium' | 'large') => {
+    onPreferencesChange({ fontSize })
+  }
+
+  const handleHighContrastToggle = () => {
+    onPreferencesChange({ highContrast: !preferences.highContrast })
+  }
+
+  const handleReadingLevelChange = (readingLevel: 'basic' | 'intermediate' | 'advanced') => {
+    onPreferencesChange({ readingLevel })
+  }
+
+  const handleVocabularyToggle = () => {
+    onPreferencesChange({ showVocabulary: !preferences.showVocabulary })
+  }
+
+  return (
+    <Card
+      className={`fixed top-4 right-4 z-10 p-3 shadow-lg ${
+        preferences.highContrast ? 'bg-gray-900 border-gray-700' : 'bg-white'
+      } ${className}`}
+      role="toolbar"
+      aria-label="Accessibility settings"
+    >
+      <div className="flex items-center gap-2">
+        {/* Language Selection */}
+        <div className="flex items-center gap-1" role="group" aria-label="Language selection">
+          <Globe className={`h-4 w-4 ${preferences.highContrast ? 'text-white' : 'text-gray-600'}`} aria-hidden="true" />
+          <Button
+            variant={preferences.language === 'en' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleLanguageChange('en')}
+            className="text-xs"
+            aria-label="Switch to English"
+            aria-pressed={preferences.language === 'en'}
+          >
+            EN
+          </Button>
+          <Button
+            variant={preferences.language === 'zh' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleLanguageChange('zh')}
+            className="text-xs"
+            aria-label="Switch to Chinese"
+            aria-pressed={preferences.language === 'zh'}
+          >
+            中文
+          </Button>
+        </div>
+
+        {/* Font Size Selection */}
+        <div className="flex items-center gap-1 border-l pl-2" role="group" aria-label="Font size selection">
+          <Type className={`h-4 w-4 ${preferences.highContrast ? 'text-white' : 'text-gray-600'}`} aria-hidden="true" />
+          <Button
+            variant={preferences.fontSize === 'small' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleFontSizeChange('small')}
+            className="text-xs"
+            aria-label="Small font size"
+            aria-pressed={preferences.fontSize === 'small'}
+          >
+            A
+          </Button>
+          <Button
+            variant={preferences.fontSize === 'medium' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleFontSizeChange('medium')}
+            className="text-sm"
+            aria-label="Medium font size"
+            aria-pressed={preferences.fontSize === 'medium'}
+          >
+            A
+          </Button>
+          <Button
+            variant={preferences.fontSize === 'large' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleFontSizeChange('large')}
+            className="text-base"
+            aria-label="Large font size"
+            aria-pressed={preferences.fontSize === 'large'}
+          >
+            A
+          </Button>
+        </div>
+
+        {/* High Contrast Toggle */}
+        <div className="flex items-center gap-1 border-l pl-2">
+          <Eye className={`h-4 w-4 ${preferences.highContrast ? 'text-white' : 'text-gray-600'}`} aria-hidden="true" />
+          <Button
+            variant={preferences.highContrast ? 'default' : 'outline'}
+            size="sm"
+            onClick={handleHighContrastToggle}
+            className="text-xs"
+            aria-label={preferences.highContrast ? 'Disable high contrast' : 'Enable high contrast'}
+            aria-pressed={preferences.highContrast}
+          >
+            <Palette className="h-3 w-3" aria-hidden="true" />
+          </Button>
+        </div>
+
+        {/* Reading Level Selection */}
+        <div className="flex items-center gap-1 border-l pl-2">
+          <BookOpen className={`h-4 w-4 ${preferences.highContrast ? 'text-white' : 'text-gray-600'}`} aria-hidden="true" />
+          <select
+            value={preferences.readingLevel}
+            onChange={(e) => handleReadingLevelChange(e.target.value as 'basic' | 'intermediate' | 'advanced')}
+            className={`text-xs border rounded px-2 py-1 ${
+              preferences.highContrast
+                ? 'bg-gray-800 border-gray-600 text-white'
+                : 'bg-white border-gray-300 text-gray-900'
+            }`}
+            aria-label="Reading level"
+          >
+            <option value="basic">{preferences.language === 'en' ? 'Basic' : '基础'}</option>
+            <option value="intermediate">{preferences.language === 'en' ? 'Intermediate' : '中级'}</option>
+            <option value="advanced">{preferences.language === 'en' ? 'Advanced' : '高级'}</option>
+          </select>
+        </div>
+
+        {/* Vocabulary Toggle */}
+        <div className="flex items-center gap-1 border-l pl-2">
+          <Button
+            variant={preferences.showVocabulary ? 'default' : 'outline'}
+            size="sm"
+            onClick={handleVocabularyToggle}
+            className="text-xs"
+            aria-label={preferences.showVocabulary ? 'Hide vocabulary' : 'Show vocabulary'}
+            aria-pressed={preferences.showVocabulary}
+          >
+            📚
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/components/student/MultilingualSupport.test.tsx
+++ b/components/student/MultilingualSupport.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MultilingualSupport } from './MultilingualSupport';
+
+describe('MultilingualSupport', () => {
+  const englishText = 'Hello World';
+  const chineseText = '你好世界';
+
+  it('displays English text when language is en', () => {
+    render(
+      <MultilingualSupport
+        en={englishText}
+        zh={chineseText}
+        language="en"
+      />
+    );
+
+    expect(screen.getByText(englishText)).toBeInTheDocument();
+    expect(screen.queryByText(chineseText)).not.toBeInTheDocument();
+  });
+
+  it('displays Chinese text when language is zh', () => {
+    render(
+      <MultilingualSupport
+        en={englishText}
+        zh={chineseText}
+        language="zh"
+      />
+    );
+
+    expect(screen.getByText(chineseText)).toBeInTheDocument();
+    expect(screen.queryByText(englishText)).not.toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <MultilingualSupport
+        en={englishText}
+        zh={chineseText}
+        language="en"
+        className="custom-class"
+      />
+    );
+
+    const span = container.querySelector('.custom-class');
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveTextContent(englishText);
+  });
+
+  it('sets correct lang attribute for English', () => {
+    const { container } = render(
+      <MultilingualSupport
+        en={englishText}
+        zh={chineseText}
+        language="en"
+      />
+    );
+
+    const span = container.querySelector('span');
+    expect(span).toHaveAttribute('lang', 'en');
+  });
+
+  it('sets correct lang attribute for Chinese', () => {
+    const { container } = render(
+      <MultilingualSupport
+        en={englishText}
+        zh={chineseText}
+        language="zh"
+      />
+    );
+
+    const span = container.querySelector('span');
+    expect(span).toHaveAttribute('lang', 'zh-CN');
+  });
+
+  it('handles empty strings', () => {
+    render(
+      <MultilingualSupport
+        en=""
+        zh=""
+        language="en"
+      />
+    );
+
+    const span = screen.getByText('', { selector: 'span' });
+    expect(span).toBeInTheDocument();
+  });
+
+  it('handles special characters in text', () => {
+    const specialEnglish = 'Hello & <World>';
+    const specialChinese = '你好 & <世界>';
+
+    render(
+      <MultilingualSupport
+        en={specialEnglish}
+        zh={specialChinese}
+        language="en"
+      />
+    );
+
+    expect(screen.getByText(specialEnglish)).toBeInTheDocument();
+  });
+});

--- a/components/student/MultilingualSupport.tsx
+++ b/components/student/MultilingualSupport.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import React from 'react'
+
+interface MultilingualSupportProps {
+  en: string
+  zh: string
+  language: 'en' | 'zh'
+  className?: string
+}
+
+/**
+ * MultilingualSupport component
+ *
+ * Displays content in either English or Chinese based on user preference.
+ * This component enables bilingual support throughout the application.
+ *
+ * @param en - English text content
+ * @param zh - Chinese text content
+ * @param language - Current language preference
+ * @param className - Optional CSS classes
+ */
+export function MultilingualSupport({ en, zh, language, className = '' }: MultilingualSupportProps) {
+  return (
+    <span className={className} lang={language === 'en' ? 'en' : 'zh-CN'}>
+      {language === 'en' ? en : zh}
+    </span>
+  )
+}

--- a/components/student/ReadingLevelAdjuster.test.tsx
+++ b/components/student/ReadingLevelAdjuster.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ReadingLevelAdjuster } from './ReadingLevelAdjuster';
+
+describe('ReadingLevelAdjuster', () => {
+  describe('Predefined adaptations', () => {
+    it('adapts "Engaging opener to capture student interest" for basic level in English', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Engaging opener to capture student interest"
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('Fun start to get students excited about learning')).toBeInTheDocument();
+    });
+
+    it('adapts "Engaging opener to capture student interest" for intermediate level in English', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Engaging opener to capture student interest"
+          level="intermediate"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('Engaging opener to capture student interest')).toBeInTheDocument();
+    });
+
+    it('adapts "Engaging opener to capture student interest" for advanced level in English', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Engaging opener to capture student interest"
+          level="advanced"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText(/Strategic pedagogical engagement mechanism/)).toBeInTheDocument();
+    });
+
+    it('adapts "Introduce key concepts and vocabulary" for basic level in Chinese', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Introduce key concepts and vocabulary"
+          level="basic"
+          language="zh"
+        />
+      );
+
+      expect(screen.getByText('学习重要的商业词汇和概念')).toBeInTheDocument();
+    });
+
+    it('adapts "Teacher-led practice activities" for intermediate level in Chinese', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Teacher-led practice activities"
+          level="intermediate"
+          language="zh"
+        />
+      );
+
+      expect(screen.getByText('教师指导的练习活动')).toBeInTheDocument();
+    });
+
+    it('adapts "Check for understanding" for advanced level in Chinese', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Check for understanding"
+          level="advanced"
+          language="zh"
+        />
+      );
+
+      expect(screen.getByText('认知同化和理解水平的形成性评估')).toBeInTheDocument();
+    });
+  });
+
+  describe('General simplification rules', () => {
+    it('simplifies vocabulary for basic level', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="We will utilize this method to facilitate learning"
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('We will use this method to help learning')).toBeInTheDocument();
+    });
+
+    it('enhances vocabulary for advanced level', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="We will use this method to help learning"
+          level="advanced"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('We will utilize this methodology to facilitate learning')).toBeInTheDocument();
+    });
+
+    it('keeps intermediate level unchanged for non-predefined content', () => {
+      const content = "This is a regular sentence";
+      render(
+        <ReadingLevelAdjuster
+          content={content}
+          level="intermediate"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText(content)).toBeInTheDocument();
+    });
+
+    it('simplifies multiple words in basic level', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="We will demonstrate and implement a comprehensive methodology"
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('We will show and do a complete method')).toBeInTheDocument();
+    });
+
+    it('replaces "analyze" with "look at" for basic level', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="Let us analyze this problem"
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('Let us look at this problem')).toBeInTheDocument();
+    });
+
+    it('replaces "subsequently" with "next" for basic level', () => {
+      render(
+        <ReadingLevelAdjuster
+          content="We will subsequently learn more"
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText('We will next learn more')).toBeInTheDocument();
+    });
+  });
+
+  describe('Language attributes', () => {
+    it('sets correct lang attribute for English', () => {
+      const { container } = render(
+        <ReadingLevelAdjuster
+          content="Test content"
+          level="intermediate"
+          language="en"
+        />
+      );
+
+      const span = container.querySelector('span');
+      expect(span).toHaveAttribute('lang', 'en');
+    });
+
+    it('sets correct lang attribute for Chinese', () => {
+      const { container } = render(
+        <ReadingLevelAdjuster
+          content="Test content"
+          level="intermediate"
+          language="zh"
+        />
+      );
+
+      const span = container.querySelector('span');
+      expect(span).toHaveAttribute('lang', 'zh-CN');
+    });
+  });
+
+  describe('Custom className', () => {
+    it('applies custom className', () => {
+      const { container } = render(
+        <ReadingLevelAdjuster
+          content="Test content"
+          level="intermediate"
+          language="en"
+          className="custom-class"
+        />
+      );
+
+      const span = container.querySelector('.custom-class');
+      expect(span).toBeInTheDocument();
+      expect(span).toHaveTextContent('Test content');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles empty strings', () => {
+      render(
+        <ReadingLevelAdjuster
+          content=""
+          level="intermediate"
+          language="en"
+        />
+      );
+
+      const span = screen.getByText('', { selector: 'span' });
+      expect(span).toBeInTheDocument();
+    });
+
+    it('handles content with no replaceable words', () => {
+      const content = "This has no special words";
+      render(
+        <ReadingLevelAdjuster
+          content={content}
+          level="basic"
+          language="en"
+        />
+      );
+
+      expect(screen.getByText(content)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/student/ReadingLevelAdjuster.tsx
+++ b/components/student/ReadingLevelAdjuster.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import React from 'react'
+
+interface ReadingLevelAdjusterProps {
+  content: string
+  level: 'basic' | 'intermediate' | 'advanced'
+  language: 'en' | 'zh'
+  className?: string
+}
+
+/**
+ * Content adaptations for different reading levels and languages
+ * Maps common educational phrases to their basic/intermediate/advanced equivalents
+ */
+const contentAdaptations: Record<string, {
+  basic: { en: string; zh: string };
+  intermediate: { en: string; zh: string };
+  advanced: { en: string; zh: string };
+}> = {
+  "Engaging opener to capture student interest": {
+    basic: {
+      en: "Fun start to get students excited about learning",
+      zh: "有趣的开始，让学生对学习感到兴奋"
+    },
+    intermediate: {
+      en: "Engaging opener to capture student interest",
+      zh: "引人入胜的开场，吸引学生的兴趣"
+    },
+    advanced: {
+      en: "Strategic pedagogical engagement mechanism designed to optimize cognitive receptivity",
+      zh: "旨在优化认知接受能力的战略性教学参与机制"
+    }
+  },
+  "Introduce key concepts and vocabulary": {
+    basic: {
+      en: "Learn important business words and ideas",
+      zh: "学习重要的商业词汇和概念"
+    },
+    intermediate: {
+      en: "Introduce key concepts and vocabulary",
+      zh: "介绍关键概念和词汇"
+    },
+    advanced: {
+      en: "Systematic exposition of fundamental theoretical constructs and specialized terminology",
+      zh: "系统阐述基础理论构念和专业术语"
+    }
+  },
+  "Teacher-led practice activities": {
+    basic: {
+      en: "Practice with teacher help",
+      zh: "在老师帮助下练习"
+    },
+    intermediate: {
+      en: "Teacher-led practice activities",
+      zh: "教师指导的练习活动"
+    },
+    advanced: {
+      en: "Structured pedagogical scaffolding through guided application exercises",
+      zh: "通过指导性应用练习进行结构化教学支架"
+    }
+  },
+  "Student-led practice and exploration": {
+    basic: {
+      en: "Practice on your own and explore",
+      zh: "独立练习和探索"
+    },
+    intermediate: {
+      en: "Student-led practice and exploration",
+      zh: "学生主导的练习和探索"
+    },
+    advanced: {
+      en: "Autonomous learning engagement with self-directed investigative methodologies",
+      zh: "自主学习参与和自我导向的研究方法"
+    }
+  },
+  "Check for understanding": {
+    basic: {
+      en: "See what you learned",
+      zh: "检查你学到了什么"
+    },
+    intermediate: {
+      en: "Check for understanding",
+      zh: "检查理解程度"
+    },
+    advanced: {
+      en: "Formative assessment of cognitive assimilation and comprehension levels",
+      zh: "认知同化和理解水平的形成性评估"
+    }
+  },
+  "Wrap up and preview next lesson": {
+    basic: {
+      en: "Finish today and see what's next",
+      zh: "总结今天并预览下一课"
+    },
+    intermediate: {
+      en: "Wrap up and preview next lesson",
+      zh: "总结并预览下一课"
+    },
+    advanced: {
+      en: "Synthesize learning outcomes and establish cognitive bridges to subsequent instruction",
+      zh: "综合学习成果并建立与后续教学的认知桥梁"
+    }
+  }
+};
+
+/**
+ * ReadingLevelAdjuster component
+ *
+ * Adapts content complexity based on reading level and language preference.
+ * Uses predefined adaptations for common phrases and applies general
+ * simplification rules for other content.
+ *
+ * @param content - Text content to adapt
+ * @param level - Reading level (basic, intermediate, advanced)
+ * @param language - Language preference (en, zh)
+ * @param className - Optional CSS classes
+ */
+export function ReadingLevelAdjuster({
+  content,
+  level,
+  language,
+  className = ''
+}: ReadingLevelAdjusterProps) {
+  // Check if we have adapted content for this text
+  const adaptation = contentAdaptations[content];
+
+  if (adaptation) {
+    return (
+      <span className={className} lang={language === 'en' ? 'en' : 'zh-CN'}>
+        {adaptation[level][language]}
+      </span>
+    );
+  }
+
+  // If no specific adaptation exists, apply general simplification rules
+  let adaptedContent = content;
+
+  if (level === 'basic') {
+    // Simplify complex sentences
+    adaptedContent = content
+      .replace(/utilize/g, 'use')
+      .replace(/facilitate/g, 'help')
+      .replace(/demonstrate/g, 'show')
+      .replace(/implement/g, 'do')
+      .replace(/analyze/g, 'look at')
+      .replace(/comprehensive/g, 'complete')
+      .replace(/fundamental/g, 'basic')
+      .replace(/methodology/g, 'method')
+      .replace(/subsequently/g, 'next')
+      .replace(/therefore/g, 'so');
+  } else if (level === 'advanced') {
+    // Add more sophisticated vocabulary where appropriate
+    adaptedContent = content
+      .replace(/help/g, 'facilitate')
+      .replace(/show/g, 'demonstrate')
+      .replace(/use/g, 'utilize')
+      .replace(/basic/g, 'fundamental')
+      .replace(/method/g, 'methodology');
+  }
+
+  return (
+    <span className={className} lang={language === 'en' ? 'en' : 'zh-CN'}>
+      {adaptedContent}
+    </span>
+  );
+}

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -22,6 +22,7 @@ export * from './phases';
 export * from './activities';
 export * from './resources';
 export * from './profiles';
+export { accessibilityPreferencesSchema } from './profiles';
 export * from './student-progress';
 export * from './activity-submissions';
 export * from './classes';

--- a/lib/db/schema/profiles.ts
+++ b/lib/db/schema/profiles.ts
@@ -7,10 +7,21 @@ import { z } from 'zod';
  */
 export const profileRoleEnum = pgEnum('profile_role', ['student', 'teacher', 'admin']);
 
+export const accessibilityPreferencesSchema = z.object({
+  language: z.enum(['en', 'zh']).default('en'),
+  fontSize: z.enum(['small', 'medium', 'large']).default('medium'),
+  highContrast: z.boolean().default(false),
+  readingLevel: z.enum(['basic', 'intermediate', 'advanced']).default('intermediate'),
+  showVocabulary: z.boolean().default(false),
+});
+
+export type AccessibilityPreferences = z.infer<typeof accessibilityPreferencesSchema>;
+
 export const profileMetadataSchema = z.object({
   grade: z.number().optional(),
   schoolName: z.string().optional(),
   preferences: z.record(z.string(), z.unknown()).optional(),
+  accessibility: accessibilityPreferencesSchema.optional(),
 });
 
 export type ProfileMetadata = z.infer<typeof profileMetadataSchema>;


### PR DESCRIPTION
## Summary

Migrated three accessibility components from v1 to v2 with database-shaped props for issue #38:

- **AccessibilityToolbar**: Comprehensive toolbar for language, font size, contrast, reading level, and vocabulary preferences  
- **MultilingualSupport**: Simple bilingual text component supporting English and Chinese
- **ReadingLevelAdjuster**: Content adaptation component with predefined translations and general simplification rules

## Database & Schema Changes

- Extended `profiles.metadata` with `accessibilityPreferencesSchema`
- Added typed Zod schema for all accessibility settings (language, fontSize, highContrast, readingLevel, showVocabulary)
- Exported `accessibilityPreferencesSchema` from `schema/index.ts` for component imports

## Component Features

- All components accept user preferences via props (parent handles DB persistence)
- Proper ARIA attributes and accessibility support throughout
- Language-aware (English/Chinese) with `lang` attributes  
- Comprehensive test coverage (34 tests total - all passing)

## Test Coverage

- **AccessibilityToolbar**: 10 tests covering rendering, callbacks, styling, and ARIA attributes
- **MultilingualSupport**: 7 tests covering language switching and edge cases
- **ReadingLevelAdjuster**: 17 tests covering predefined adaptations, simplification rules, and language attributes

## Test Results

All tests passing:
```
✓ components/student/AccessibilityToolbar.test.tsx (10 tests)
✓ components/student/MultilingualSupport.test.tsx (7 tests)  
✓ components/student/ReadingLevelAdjuster.test.tsx (17 tests)
```

Zero linting errors.

## Related

Closes #38  
Part of Epic #41 (V1 Component Migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)