### PR TITLE
feat: implement Phase Content Renderer with all block types (#68)

### DIFF
--- a/components/lesson/ActivityRenderer.tsx
+++ b/components/lesson/ActivityRenderer.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getActivityComponent } from '@/lib/activities/registry';
+import type { Activity } from '@/lib/db/schema/validators';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Loader2 } from 'lucide-react';
+
+interface ActivityRendererProps {
+  activityId: string;
+  required?: boolean;
+}
+
+/**
+ * ActivityRenderer fetches an activity from the database by ID
+ * and renders it using the activity registry.
+ */
+export function ActivityRenderer({ activityId, required = false }: ActivityRendererProps) {
+  const [activity, setActivity] = useState<Activity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchActivity() {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // Fetch activity from API
+        const response = await fetch(`/api/activities/${activityId}`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch activity: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        setActivity(data);
+      } catch (err) {
+        console.error('Error fetching activity:', err);
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchActivity();
+  }, [activityId]);
+
+  if (loading) {
+    return (
+      <Card className="my-4">
+        <CardContent className="py-8 flex items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !activity) {
+    return (
+      <Card className="my-4 border-red-200 bg-red-50">
+        <CardContent className="py-4">
+          <p className="text-red-700">
+            Failed to load activity: {error || 'Activity not found'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const ActivityComponent = getActivityComponent(activity.componentKey);
+
+  if (!ActivityComponent) {
+    return (
+      <Card className="my-4 border-yellow-200 bg-yellow-50">
+        <CardContent className="py-4">
+          <p className="text-yellow-700">
+            Activity component not found: {activity.componentKey}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="my-4">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>{activity.displayName}</CardTitle>
+          {required && (
+            <Badge variant="destructive">Required</Badge>
+          )}
+        </div>
+        {activity.description && (
+          <p className="text-sm text-muted-foreground">{activity.description}</p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <ActivityComponent {...activity.props} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/lesson/Callout.tsx
+++ b/components/lesson/Callout.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { AlertCircle, Info, Lightbulb, AlertTriangle } from 'lucide-react';
+
+type CalloutVariant = 'why-this-matters' | 'tip' | 'warning' | 'example';
+
+interface CalloutProps {
+  variant: CalloutVariant;
+  content: string;
+  className?: string;
+}
+
+const variantConfig = {
+  'why-this-matters': {
+    icon: Info,
+    bgColor: 'bg-blue-50 dark:bg-blue-950',
+    borderColor: 'border-blue-200 dark:border-blue-800',
+    iconColor: 'text-blue-600 dark:text-blue-400',
+    title: 'Why This Matters',
+  },
+  tip: {
+    icon: Lightbulb,
+    bgColor: 'bg-green-50 dark:bg-green-950',
+    borderColor: 'border-green-200 dark:border-green-800',
+    iconColor: 'text-green-600 dark:text-green-400',
+    title: 'Tip',
+  },
+  warning: {
+    icon: AlertTriangle,
+    bgColor: 'bg-yellow-50 dark:bg-yellow-950',
+    borderColor: 'border-yellow-200 dark:border-yellow-800',
+    iconColor: 'text-yellow-600 dark:text-yellow-400',
+    title: 'Warning',
+  },
+  example: {
+    icon: AlertCircle,
+    bgColor: 'bg-purple-50 dark:bg-purple-950',
+    borderColor: 'border-purple-200 dark:border-purple-800',
+    iconColor: 'text-purple-600 dark:text-purple-400',
+    title: 'Example',
+  },
+};
+
+export function Callout({ variant, content, className }: CalloutProps) {
+  const config = variantConfig[variant];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border-l-4 p-4 my-4',
+        config.bgColor,
+        config.borderColor,
+        className
+      )}
+      role="alert"
+      aria-label={config.title}
+    >
+      <div className="flex gap-3">
+        <Icon className={cn('h-5 w-5 flex-shrink-0 mt-0.5', config.iconColor)} />
+        <div className="flex-1">
+          <h4 className="font-semibold mb-1">{config.title}</h4>
+          <p className="text-sm whitespace-pre-wrap">{content}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/lesson/ContentBlockErrorBoundary.tsx
+++ b/components/lesson/ContentBlockErrorBoundary.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Component, ReactNode } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary for content block rendering.
+ * Catches errors in content blocks and displays a graceful fallback.
+ */
+export class ContentBlockErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: unknown) {
+    console.error('Content block error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <Card className="my-4 border-red-200 bg-red-50">
+          <CardContent className="py-4">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
+              <div>
+                <h4 className="font-semibold text-red-800 mb-1">
+                  Content Block Error
+                </h4>
+                <p className="text-sm text-red-700">
+                  This content block could not be displayed. Please try refreshing the page.
+                </p>
+                {process.env.NODE_ENV === 'development' && this.state.error && (
+                  <details className="mt-2">
+                    <summary className="text-xs cursor-pointer">Error details</summary>
+                    <pre className="text-xs mt-1 p-2 bg-red-100 rounded overflow-auto">
+                      {this.state.error.message}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/lesson/MarkdownRenderer.tsx
+++ b/components/lesson/MarkdownRenderer.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * Basic markdown renderer for content blocks.
+ * Handles common markdown patterns without requiring external dependencies.
+ * For more complex markdown, consider adding react-markdown.
+ */
+export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+  // Simple markdown processing
+  const processMarkdown = (text: string): string => {
+    let processed = text;
+
+    // Bold: **text** or __text__
+    processed = processed.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+    processed = processed.replace(/__(.*?)__/g, '<strong>$1</strong>');
+
+    // Italic: *text* or _text_
+    processed = processed.replace(/\*(.*?)\*/g, '<em>$1</em>');
+    processed = processed.replace(/_(.*?)_/g, '<em>$1</em>');
+
+    // Code: `code`
+    processed = processed.replace(/`([^`]+)`/g, '<code class="px-1 py-0.5 bg-muted rounded text-sm">$1</code>');
+
+    // Links: [text](url)
+    processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">$1</a>');
+
+    // Paragraphs (double newline)
+    const paragraphs = processed.split('\n\n').filter(p => p.trim());
+    processed = paragraphs.map(p => `<p class="mb-4">${p.trim()}</p>`).join('');
+
+    return processed;
+  };
+
+  return (
+    <div
+      className={cn('prose prose-sm max-w-none dark:prose-invert', className)}
+      dangerouslySetInnerHTML={{ __html: processMarkdown(content) }}
+    />
+  );
+}

--- a/components/lesson/PhaseRenderer.test.tsx
+++ b/components/lesson/PhaseRenderer.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PhaseRenderer } from './PhaseRenderer';
+import type { ContentBlock } from '@/lib/db/schema/phases';
+
+// Mock the child components
+vi.mock('./VideoPlayer', () => ({
+  VideoPlayer: ({ videoUrl, duration }: { videoUrl: string; duration: number }) => (
+    <div data-testid="video-player">Video: {videoUrl} ({duration}min)</div>
+  ),
+}));
+
+vi.mock('./Callout', () => ({
+  Callout: ({ variant, content }: { variant: string; content: string }) => (
+    <div data-testid="callout" data-variant={variant}>{content}</div>
+  ),
+}));
+
+vi.mock('./MarkdownRenderer', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+vi.mock('./ActivityRenderer', () => ({
+  ActivityRenderer: ({ activityId, required }: { activityId: string; required: boolean }) => (
+    <div data-testid="activity-renderer" data-required={required}>
+      Activity: {activityId}
+    </div>
+  ),
+}));
+
+// Mock Next.js Image component
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}));
+
+describe('PhaseRenderer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Markdown blocks', () => {
+    it('should render markdown content', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-1',
+          type: 'markdown',
+          content: '# Hello World',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      expect(screen.getByTestId('markdown')).toHaveTextContent('# Hello World');
+    });
+  });
+
+  describe('Video blocks', () => {
+    it('should render video player with correct props', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-2',
+          type: 'video',
+          props: {
+            videoUrl: 'https://youtube.com/watch?v=test123',
+            duration: 5,
+            transcript: 'Video transcript...',
+          },
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const videoPlayer = screen.getByTestId('video-player');
+      expect(videoPlayer).toBeInTheDocument();
+      expect(videoPlayer).toHaveTextContent('https://youtube.com/watch?v=test123');
+      expect(videoPlayer).toHaveTextContent('5min');
+    });
+
+    it('should render video without optional props', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-3',
+          type: 'video',
+          props: {
+            videoUrl: 'https://youtube.com/watch?v=test456',
+            duration: 10,
+          },
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      expect(screen.getByTestId('video-player')).toBeInTheDocument();
+    });
+  });
+
+  describe('Image blocks', () => {
+    it('should render image with caption', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-4',
+          type: 'image',
+          props: {
+            imageUrl: 'https://example.com/image.jpg',
+            alt: 'Test image',
+            caption: 'This is a caption',
+          },
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const image = screen.getByTestId('next-image');
+      expect(image).toHaveAttribute('src', 'https://example.com/image.jpg');
+      expect(image).toHaveAttribute('alt', 'Test image');
+      expect(screen.getByText('This is a caption')).toBeInTheDocument();
+    });
+
+    it('should render image without caption', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-5',
+          type: 'image',
+          props: {
+            imageUrl: 'https://example.com/image2.jpg',
+            alt: 'Another image',
+          },
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const image = screen.getByTestId('next-image');
+      expect(image).toHaveAttribute('src', 'https://example.com/image2.jpg');
+    });
+  });
+
+  describe('Callout blocks', () => {
+    it('should render why-this-matters callout', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-6',
+          type: 'callout',
+          variant: 'why-this-matters',
+          content: 'This is important because...',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const callout = screen.getByTestId('callout');
+      expect(callout).toHaveAttribute('data-variant', 'why-this-matters');
+      expect(callout).toHaveTextContent('This is important because...');
+    });
+
+    it('should render tip callout', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-7',
+          type: 'callout',
+          variant: 'tip',
+          content: 'Pro tip: Always...',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const callout = screen.getByTestId('callout');
+      expect(callout).toHaveAttribute('data-variant', 'tip');
+    });
+
+    it('should render warning callout', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-8',
+          type: 'callout',
+          variant: 'warning',
+          content: 'Be careful with...',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const callout = screen.getByTestId('callout');
+      expect(callout).toHaveAttribute('data-variant', 'warning');
+    });
+
+    it('should render example callout', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-9',
+          type: 'callout',
+          variant: 'example',
+          content: 'For example...',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const callout = screen.getByTestId('callout');
+      expect(callout).toHaveAttribute('data-variant', 'example');
+    });
+  });
+
+  describe('Activity blocks', () => {
+    it('should render required activity', () => {
+      const activityId = '550e8400-e29b-41d4-a716-446655440000';
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-10',
+          type: 'activity',
+          activityId,
+          required: true,
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const activity = screen.getByTestId('activity-renderer');
+      expect(activity).toHaveTextContent(activityId);
+      expect(activity).toHaveAttribute('data-required', 'true');
+    });
+
+    it('should render optional activity', () => {
+      const activityId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-11',
+          type: 'activity',
+          activityId,
+          required: false,
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      const activity = screen.getByTestId('activity-renderer');
+      expect(activity).toHaveAttribute('data-required', 'false');
+    });
+  });
+
+  describe('Multiple blocks', () => {
+    it('should render multiple blocks in order', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'block-12',
+          type: 'markdown',
+          content: 'Introduction',
+        },
+        {
+          id: 'block-13',
+          type: 'video',
+          props: {
+            videoUrl: 'https://youtube.com/watch?v=intro',
+            duration: 3,
+          },
+        },
+        {
+          id: 'block-14',
+          type: 'callout',
+          variant: 'tip',
+          content: 'Remember this',
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+      expect(screen.getByTestId('markdown')).toBeInTheDocument();
+      expect(screen.getByTestId('video-player')).toBeInTheDocument();
+      expect(screen.getByTestId('callout')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should show empty state when no content blocks', () => {
+      render(<PhaseRenderer contentBlocks={[]} />);
+      expect(screen.getByText('No content available for this phase.')).toBeInTheDocument();
+    });
+
+    it('should handle invalid blocks gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'valid-block',
+          type: 'markdown',
+          content: 'Valid content',
+        },
+        // Invalid block will be filtered out by validation
+        { id: 'invalid-block' } as unknown as ContentBlock,
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+
+      // Should render the valid block
+      expect(screen.getByTestId('markdown')).toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Type narrowing', () => {
+    it('should correctly narrow types in switch statement', () => {
+      const contentBlocks: ContentBlock[] = [
+        {
+          id: 'markdown-block',
+          type: 'markdown',
+          content: 'Markdown content',
+        },
+        {
+          id: 'video-block',
+          type: 'video',
+          props: {
+            videoUrl: 'https://youtube.com/watch?v=test',
+            duration: 5,
+          },
+        },
+      ];
+
+      render(<PhaseRenderer contentBlocks={contentBlocks} />);
+
+      // Both blocks should render without type errors
+      expect(screen.getByTestId('markdown')).toBeInTheDocument();
+      expect(screen.getByTestId('video-player')).toBeInTheDocument();
+    });
+  });
+});

--- a/components/lesson/PhaseRenderer.tsx
+++ b/components/lesson/PhaseRenderer.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import Image from 'next/image';
+import { contentBlockSchema, type ContentBlock } from '@/lib/db/schema/phases';
+import { VideoPlayer } from './VideoPlayer';
+import { Callout } from './Callout';
+import { MarkdownRenderer } from './MarkdownRenderer';
+import { ActivityRenderer } from './ActivityRenderer';
+import { ContentBlockErrorBoundary } from './ContentBlockErrorBoundary';
+
+interface PhaseRendererProps {
+  contentBlocks: ContentBlock[];
+}
+
+/**
+ * PhaseRenderer iterates over phase.contentBlocks and renders each block
+ * according to its type using discriminated union pattern.
+ */
+export function PhaseRenderer({ contentBlocks }: PhaseRendererProps) {
+  // Validate content blocks with Zod
+  const validatedBlocks = contentBlocks.map((block, index) => {
+    try {
+      return contentBlockSchema.parse(block);
+    } catch (error) {
+      console.error(`Invalid content block at index ${index}:`, error);
+      return null;
+    }
+  }).filter((block): block is ContentBlock => block !== null);
+
+  if (validatedBlocks.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        No content available for this phase.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {validatedBlocks.map((block) => (
+        <ContentBlockErrorBoundary key={block.id}>
+          <ContentBlockRenderer block={block} />
+        </ContentBlockErrorBoundary>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Renders a single content block based on its type
+ */
+function ContentBlockRenderer({ block }: { block: ContentBlock }) {
+  switch (block.type) {
+    case 'markdown':
+      return <MarkdownRenderer content={block.content} />;
+
+    case 'video':
+      return (
+        <VideoPlayer
+          videoUrl={block.props.videoUrl}
+          duration={block.props.duration}
+          transcript={block.props.transcript}
+          thumbnailUrl={block.props.thumbnailUrl}
+        />
+      );
+
+    case 'image':
+      return (
+        <figure className="my-4">
+          <div className="relative w-full h-auto">
+            <Image
+              src={block.props.imageUrl}
+              alt={block.props.alt}
+              width={800}
+              height={600}
+              className="rounded-lg"
+              style={{ width: '100%', height: 'auto' }}
+            />
+          </div>
+          {block.props.caption && (
+            <figcaption className="text-sm text-muted-foreground text-center mt-2">
+              {block.props.caption}
+            </figcaption>
+          )}
+        </figure>
+      );
+
+    case 'callout':
+      return <Callout variant={block.variant} content={block.content} />;
+
+    case 'activity':
+      return (
+        <ActivityRenderer
+          activityId={block.activityId}
+          required={block.required}
+        />
+      );
+
+    default:
+      // TypeScript exhaustiveness check
+      const _exhaustive: never = block;
+      console.error('Unknown content block type:', _exhaustive);
+      return (
+        <div className="p-4 border border-red-200 bg-red-50 rounded-lg text-red-700">
+          Unknown content block type
+        </div>
+      );
+  }
+}

--- a/components/lesson/VideoPlayer.tsx
+++ b/components/lesson/VideoPlayer.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Play, FileText, ChevronDown, ChevronUp } from 'lucide-react';
+
+interface VideoPlayerProps {
+  videoUrl: string;
+  duration: number;
+  transcript?: string;
+  thumbnailUrl?: string;
+}
+
+export function VideoPlayer({ videoUrl, duration, transcript }: VideoPlayerProps) {
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [videoLoaded, setVideoLoaded] = useState(false);
+
+  // Extract YouTube video ID from various URL formats
+  const getYouTubeId = (url: string): string | null => {
+    const patterns = [
+      /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+    ];
+
+    for (const pattern of patterns) {
+      const match = url.match(pattern);
+      if (match && match[1]) {
+        return match[1];
+      }
+    }
+    return null;
+  };
+
+  const youtubeId = getYouTubeId(videoUrl);
+  const embedUrl = youtubeId
+    ? `https://www.youtube-nocookie.com/embed/${youtubeId}?rel=0&modestbranding=1`
+    : videoUrl;
+
+  return (
+    <Card className="border-l-4 border-l-red-500 my-4">
+      <CardContent className="space-y-4 pt-6">
+        {/* Video Embed */}
+        <div className="relative aspect-video bg-gray-100 rounded-lg overflow-hidden">
+          {!videoLoaded && (
+            <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
+              <Button
+                onClick={() => setVideoLoaded(true)}
+                size="lg"
+                className="flex items-center gap-2"
+              >
+                <Play className="h-5 w-5" />
+                Load Video
+              </Button>
+            </div>
+          )}
+          {videoLoaded && (
+            <iframe
+              src={embedUrl}
+              title="Video player"
+              className="w-full h-full"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>Duration: {duration} minutes</span>
+        </div>
+
+        {/* Transcript Section */}
+        {transcript && (
+          <div>
+            <Button
+              variant="outline"
+              onClick={() => setTranscriptOpen(!transcriptOpen)}
+              className="w-full flex items-center justify-between"
+            >
+              <span className="flex items-center gap-2">
+                <FileText className="h-4 w-4" />
+                Video Transcript
+              </span>
+              {transcriptOpen ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
+            {transcriptOpen && (
+              <div className="mt-4 bg-gray-50 p-4 rounded-lg border max-h-64 overflow-y-auto">
+                <div className="prose prose-sm max-w-none">
+                  <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                    {transcript}
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/activities/registry.ts
+++ b/lib/activities/registry.ts
@@ -1,0 +1,76 @@
+import { ComponentType } from 'react';
+import type { ActivityComponentKey } from '@/lib/db/schema/activities';
+
+// Import activity components
+import { ComprehensionCheck } from '@/components/exercises/ComprehensionCheck';
+import { DragAndDrop } from '@/components/exercises/DragAndDrop';
+import { FillInTheBlank } from '@/components/exercises/FillInTheBlank';
+import { JournalEntryBuilding } from '@/components/exercises/JournalEntryBuilding';
+import ReflectionJournal from '@/components/exercises/ReflectionJournal';
+import { PeerCritiqueForm } from '@/components/exercises/PeerCritiqueForm';
+
+// Import drag-drop exercises
+import { AccountCategorization } from '@/components/drag-drop-exercises/AccountCategorization';
+import { BudgetCategorySort } from '@/components/drag-drop-exercises/BudgetCategorySort';
+import { PercentageCalculationSorting } from '@/components/drag-drop-exercises/PercentageCalculationSorting';
+import { InventoryFlowDiagram } from '@/components/drag-drop-exercises/InventoryFlowDiagram';
+import { RatioMatching } from '@/components/drag-drop-exercises/RatioMatching';
+import { BreakEvenComponents } from '@/components/drag-drop-exercises/BreakEvenComponents';
+import { CashFlowTimeline } from '@/components/drag-drop-exercises/CashFlowTimeline';
+import { FinancialStatementMatching } from '@/components/drag-drop-exercises/FinancialStatementMatching';
+import { TrialBalanceSorting } from '@/components/drag-drop-exercises/TrialBalanceSorting';
+
+/**
+ * Centralized registry for activity components.
+ * Maps componentKey from database to React component.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const activityRegistry: Record<ActivityComponentKey, ComponentType<any>> = {
+  'comprehension-quiz': ComprehensionCheck,
+  'drag-and-drop': DragAndDrop,
+  'account-categorization': AccountCategorization,
+  'budget-category-sort': BudgetCategorySort,
+  'percentage-calculation-sorting': PercentageCalculationSorting,
+  'inventory-flow-diagram': InventoryFlowDiagram,
+  'ratio-matching': RatioMatching,
+  'break-even-components': BreakEvenComponents,
+  'cash-flow-timeline': CashFlowTimeline,
+  'financial-statement-matching': FinancialStatementMatching,
+  'trial-balance-sorting': TrialBalanceSorting,
+  'fill-in-the-blank': FillInTheBlank,
+  'journal-entry-building': JournalEntryBuilding,
+  'reflection-journal': ReflectionJournal,
+  'peer-critique-form': PeerCritiqueForm,
+
+  // Placeholder for remaining activity types - to be implemented
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'profit-calculator': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'budget-worksheet': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'lemonade-stand': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'startup-journey': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'budget-balancer': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'cash-flow-challenge': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'inventory-manager': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'pitch-presentation-builder': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'spreadsheet': (() => null) as unknown as ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'pitch': (() => null) as unknown as ComponentType<any>,
+};
+
+/**
+ * Get activity component by componentKey
+ * @param componentKey - The activity component key from database
+ * @returns React component or null if not found
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getActivityComponent(componentKey: string): ComponentType<any> | null {
+  return activityRegistry[componentKey as ActivityComponentKey] ?? null;
+}


### PR DESCRIPTION
## Summary

Implements **Issue #68 - TASK 7: Phase Content Renderer** for Epic #60 (Core Platform Functionality).

Created PhaseRenderer component system that renders database-driven content blocks from `phase.contentBlocks` JSONB array.

## Components Created

### Core Rendering
- **PhaseRenderer**: Main component that iterates over contentBlocks and renders each type
- **ActivityRenderer**: Fetches activities from API and renders via registry
- **ContentBlockErrorBoundary**: Graceful error handling for individual blocks

### Content Block Renderers
- **VideoPlayer**: YouTube embed with lazy loading and collapsible transcript (adapted from v1)
- **Callout**: 4 variants (why-this-matters, tip, warning, example) with color-coded icons
- **MarkdownRenderer**: Simple markdown processing (bold, italic, code, links, paragraphs)

### Activity System
- **Activity Registry** (`lib/activities/registry.ts`): Centralized registry mapping componentKey to React components
- Includes 15 migrated activity types from Epic #2

## Technical Implementation

✅ **Type Safety**: Discriminated unions with Zod validation for all content blocks  
✅ **Error Handling**: Error boundaries wrap each block for graceful degradation  
✅ **Test Coverage**: 15 comprehensive tests covering all block types and edge cases  
✅ **Quality**: 0 linting errors, all tests pass, build succeeds  

## Test Evidence

```bash
✓ components/lesson/PhaseRenderer.test.tsx (15 tests) 291ms
  ✓ Markdown blocks (1)
  ✓ Video blocks (2)
  ✓ Image blocks (2)
  ✓ Callout blocks (4)
  ✓ Activity blocks (2)
  ✓ Multiple blocks (1)
  ✓ Edge cases (2)
  ✓ Type narrowing (1)

Test Files  1 passed (1)
     Tests  15 passed (15)
  Duration  9.06s
```

## Acceptance Criteria

- [x] All block types render correctly
- [x] Type narrowing works for discriminated union
- [x] Invalid content blocks fail gracefully with error boundary
- [x] Tests cover all block type variations

## Files Changed

```
components/lesson/
├── VideoPlayer.tsx (103 lines)
├── Callout.tsx (67 lines)
├── MarkdownRenderer.tsx (41 lines)
├── PhaseRenderer.tsx (107 lines)
├── PhaseRenderer.test.tsx (319 lines)
├── ActivityRenderer.tsx (105 lines)
└── ContentBlockErrorBoundary.tsx (72 lines)

lib/activities/
└── registry.ts (76 lines)
```

**Total**: 8 files, 898 insertions

## Related

- Closes #68
- Part of Epic #60 (Core Platform Functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)