### PR TITLE
feat: TASK 15 assessment submission API

### DIFF
--- a/app/api/progress/assessment/route.test.ts
+++ b/app/api/progress/assessment/route.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+      from: mockFrom,
+    }),
+  ),
+}));
+
+const { POST } = await import('./route');
+
+function buildRequest(body: unknown) {
+  return new Request('http://localhost/api/progress/assessment', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const baseActivity = {
+  id: '7a0bfc56-4b5a-4c41-a90e-0e5cc2e7319b',
+  componentKey: 'comprehension-quiz',
+  displayName: 'Quick Check',
+  description: 'Assess understanding',
+  props: {
+    title: 'Knowledge Check',
+    description: 'Two question quiz',
+    showExplanations: false,
+    allowRetry: true,
+    questions: [
+      {
+        id: 'q1',
+        text: 'Choose the correct option',
+        type: 'multiple-choice',
+        options: ['Yes', 'No'],
+        correctAnswer: 'Yes',
+      },
+      {
+        id: 'q2',
+        text: 'Type the matching word',
+        type: 'short-answer',
+        correctAnswer: 'Ledger',
+      },
+    ],
+  },
+  gradingConfig: {
+    autoGrade: true,
+    passingScore: 70,
+    partialCredit: false,
+  },
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('POST /api/progress/assessment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    });
+
+    mockSingle.mockResolvedValue({ data: baseActivity, error: null });
+    mockInsert.mockResolvedValue({ error: null });
+
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'activities') {
+        return { select: mockSelect };
+      }
+
+      if (table === 'activity_submissions') {
+        return { insert: mockInsert };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const response = await POST(buildRequest({
+      activityId: baseActivity.id,
+      answers: { q1: 'Yes' },
+    }));
+
+    expect(response.status).toBe(401);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/unauthorized/i);
+  });
+
+  it('validates the incoming payload', async () => {
+    const response = await POST(buildRequest({ activityId: 'not-a-uuid', answers: {} }));
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.error).toBe('Invalid payload');
+  });
+
+  it('returns 404 when the activity cannot be found', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'No rows' },
+    });
+
+    const response = await POST(buildRequest({
+      activityId: baseActivity.id,
+      answers: { q1: 'Yes' },
+    }));
+
+    expect(response.status).toBe(404);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/not found/i);
+  });
+
+  it('scores the submission on the server and persists it', async () => {
+    const response = await POST(buildRequest({
+      activityId: baseActivity.id,
+      answers: {
+        q1: 'Yes',
+        q2: 'ledger',
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.score).toBe(2);
+    expect(payload.maxScore).toBe(2);
+    expect(payload.percentage).toBe(100);
+    expect(payload.feedback).toMatch(/great work/i);
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-123',
+        activity_id: baseActivity.id,
+        score: 2,
+        max_score: 2,
+      }),
+    );
+  });
+
+  it('returns 422 when the activity is not auto-gradable', async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        ...baseActivity,
+        gradingConfig: { autoGrade: false },
+      },
+      error: null,
+    });
+
+    const response = await POST(buildRequest({
+      activityId: baseActivity.id,
+      answers: { q1: 'Yes' },
+    }));
+
+    expect(response.status).toBe(422);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/not configured/i);
+  });
+});

--- a/app/api/progress/assessment/route.ts
+++ b/app/api/progress/assessment/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { calculateScore } from '@/lib/assessments/scoring';
+import { submissionDataSchema } from '@/lib/db/schema/activity-submissions';
+import { selectActivitySchema } from '@/lib/db/schema/validators';
+import { createClient } from '@/lib/supabase/server';
+
+const requestSchema = z.object({
+  activityId: z.string().uuid(),
+  answers: z.record(z.string(), z.unknown()),
+  interactionHistory: z.array(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+type RequestPayload = z.infer<typeof requestSchema>;
+
+function buildBadRequest(details: Record<string, unknown> | string) {
+  return NextResponse.json(
+    typeof details === 'string'
+      ? { error: details }
+      : {
+          error: 'Invalid payload',
+          details,
+        },
+    { status: 400 },
+  );
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data,
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !data?.user) {
+      return NextResponse.json(
+        { error: authError?.message ?? 'Unauthorized' },
+        { status: 401 },
+      );
+    }
+
+    let payload: RequestPayload;
+    try {
+      const body = await request.json();
+      const parsed = requestSchema.safeParse(body);
+      if (!parsed.success) {
+        return buildBadRequest(parsed.error.flatten().fieldErrors);
+      }
+      payload = parsed.data;
+    } catch (parseError) {
+      return buildBadRequest(
+        parseError instanceof Error ? parseError.message : 'Unable to parse request body',
+      );
+    }
+
+    if (Object.keys(payload.answers).length === 0) {
+      return buildBadRequest('answers must include at least one entry.');
+    }
+
+    const {
+      data: activityRecord,
+      error: activityError,
+    } = await supabase
+      .from('activities')
+      .select(
+        `
+          id,
+          componentKey:component_key,
+          displayName:display_name,
+          description,
+          props,
+          gradingConfig:grading_config,
+          createdAt:created_at,
+          updatedAt:updated_at
+        `,
+      )
+      .eq('id', payload.activityId)
+      .single();
+
+    if (activityError || !activityRecord) {
+      const status = activityError?.code === 'PGRST116' ? 404 : 500;
+      const message = status === 404 ? 'Activity not found' : activityError?.message ?? 'Unable to load activity';
+      return NextResponse.json({ error: message }, { status });
+    }
+
+    let activity;
+    try {
+      activity = selectActivitySchema.parse({
+        ...activityRecord,
+        createdAt: new Date(activityRecord.createdAt),
+        updatedAt: new Date(activityRecord.updatedAt),
+      });
+    } catch (error) {
+      console.error('Invalid activity configuration', error);
+      return NextResponse.json({ error: 'Activity configuration is invalid.' }, { status: 500 });
+    }
+
+    let score;
+    try {
+      score = calculateScore(activity, payload.answers);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to score submission';
+      return NextResponse.json({ error: message }, { status: 422 });
+    }
+
+    const submissionData = submissionDataSchema.parse({
+      answers: payload.answers,
+      interactionHistory: payload.interactionHistory,
+      metadata: payload.metadata,
+    });
+
+    const now = new Date().toISOString();
+
+    const { error: insertError } = await supabase
+      .from('activity_submissions')
+      .insert({
+        user_id: data.user.id,
+        activity_id: payload.activityId,
+        submission_data: submissionData,
+        score: score.score,
+        max_score: score.maxScore,
+        feedback: score.feedback,
+        submitted_at: now,
+        graded_at: now,
+      });
+
+    if (insertError) {
+      return NextResponse.json(
+        { error: insertError.message ?? 'Unable to save submission' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      score: score.score,
+      maxScore: score.maxScore,
+      percentage: score.percentage,
+      feedback: score.feedback,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : 'Unexpected error while scoring assessment',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/assessments/scoring.ts
+++ b/lib/assessments/scoring.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod';
+
+import type { Activity } from '@/lib/db/schema/validators';
+
+const DEFAULT_PASSING_SCORE = 70;
+
+const questionSchema = z.object({
+  id: z.string(),
+  correctAnswer: z.union([z.string(), z.array(z.string())]),
+});
+
+const sentenceSchema = z.object({
+  id: z.string(),
+  answer: z.string(),
+  alternativeAnswers: z.array(z.string()).optional(),
+});
+
+type Question = z.infer<typeof questionSchema>;
+type Sentence = z.infer<typeof sentenceSchema>;
+
+export interface ScoreResult {
+  /** Number of correctly answered items */
+  score: number;
+  /** Total number of gradable items */
+  maxScore: number;
+  /** Percentage score in the 0-100 range */
+  percentage: number;
+  /** Human-readable feedback for the student */
+  feedback: string;
+}
+
+/** Normalize answers for comparison regardless of whitespace/case/order */
+function normalizeAnswer(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeAnswer(entry))
+      .sort()
+      .join('|');
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value).trim().toLowerCase();
+  }
+
+  if (value == null) {
+    return '';
+  }
+
+  return JSON.stringify(value);
+}
+
+function calculatePercentage(correct: number, total: number): number {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.round((correct / total) * 100);
+}
+
+function buildFeedback(percentage: number, passingScore: number): string {
+  if (percentage >= passingScore) {
+    return `Great work! You scored ${percentage}% which meets the goal.`;
+  }
+
+  if (percentage === 0) {
+    return 'Keep going! Review the lesson and try again.';
+  }
+
+  return `You scored ${percentage}%. Review the hints and give it another shot.`;
+}
+
+function hasQuestionBank(props: Activity['props']): props is Activity['props'] & {
+  questions: Question[];
+} {
+  return Boolean(props && typeof props === 'object' && Array.isArray((props as { questions?: unknown }).questions));
+}
+
+function hasSentences(props: Activity['props']): props is Activity['props'] & {
+  sentences: Sentence[];
+} {
+  return Boolean(props && typeof props === 'object' && Array.isArray((props as { sentences?: unknown }).sentences));
+}
+
+function scoreQuestions(questions: Question[], answers: Record<string, unknown>) {
+  const parsed = questions.map((question) => questionSchema.parse(question));
+
+  let correct = 0;
+  parsed.forEach((question) => {
+    const response = answers[question.id];
+
+    if (Array.isArray(question.correctAnswer)) {
+      const expected = normalizeAnswer(question.correctAnswer);
+      const provided = normalizeAnswer(Array.isArray(response) ? response : [response]);
+      if (expected === provided) {
+        correct += 1;
+      }
+      return;
+    }
+
+    if (normalizeAnswer(question.correctAnswer) === normalizeAnswer(response)) {
+      correct += 1;
+    }
+  });
+
+  return { correct, total: parsed.length };
+}
+
+function scoreSentences(sentences: Sentence[], answers: Record<string, unknown>) {
+  const parsed = sentences.map((sentence) => sentenceSchema.parse(sentence));
+
+  let correct = 0;
+  parsed.forEach((sentence) => {
+    const provided = answers[sentence.id];
+    if (!provided) {
+      return;
+    }
+
+    const accepted = [sentence.answer, ...(sentence.alternativeAnswers ?? [])];
+    const normalizedAccepted = accepted.map((value) => normalizeAnswer(value));
+    const normalizedProvided = normalizeAnswer(provided);
+
+    if (normalizedAccepted.includes(normalizedProvided)) {
+      correct += 1;
+    }
+  });
+
+  return { correct, total: parsed.length };
+}
+
+export function calculateScore(
+  activity: Activity,
+  answers: Record<string, unknown>,
+): ScoreResult {
+  if (!activity.gradingConfig?.autoGrade) {
+    throw new Error('Activity is not configured for auto-grading.');
+  }
+
+  const passingScore = activity.gradingConfig.passingScore ?? DEFAULT_PASSING_SCORE;
+
+  let correct = 0;
+  let total = 0;
+
+  if (hasQuestionBank(activity.props)) {
+    const result = scoreQuestions(activity.props.questions as Question[], answers);
+    correct = result.correct;
+    total = result.total;
+  } else if (hasSentences(activity.props)) {
+    const result = scoreSentences(activity.props.sentences as Sentence[], answers);
+    correct = result.correct;
+    total = result.total;
+  } else {
+    throw new Error('Activity type is not yet supported for auto-grading.');
+  }
+
+  const percentage = calculatePercentage(correct, total);
+
+  return {
+    score: correct,
+    maxScore: total,
+    percentage,
+    feedback: buildFeedback(percentage, passingScore),
+  };
+}


### PR DESCRIPTION
## Summary
- add server-side scoring helper with quiz + fill-in-the-blank support
- add /api/progress/assessment endpoint with Supabase auth, validation, and persistence
- cover the route with Vitest mocks to enforce auth, validation, scoring, and persistence

## Testing
- npm run test -- app/api/progress/assessment/route.test.ts

Closes #76