### PR TITLE
Fix: Login redirect and profile fetch issues (#104)

### DIFF
--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -53,7 +53,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         .from('profiles')
         .select('*')
         .eq('id', userId)
-        .single();
+        .maybeSingle();
 
       if (error) {
         console.error('Error fetching profile:', error);

--- a/proxy.ts
+++ b/proxy.ts
@@ -57,7 +57,7 @@ export async function proxy(request: NextRequest) {
   // Redirect unauthenticated users to login
   if (!user) {
     const redirectUrl = request.nextUrl.clone();
-    redirectUrl.pathname = '/login';
+    redirectUrl.pathname = '/auth/login';
     redirectUrl.searchParams.set('redirect', path);
     return NextResponse.redirect(redirectUrl);
   }
@@ -67,12 +67,12 @@ export async function proxy(request: NextRequest) {
     .from('profiles')
     .select('role')
     .eq('id', user.id)
-    .single();
+    .maybeSingle();
 
   if (!profile) {
     // User has no profile, redirect to login
     const redirectUrl = request.nextUrl.clone();
-    redirectUrl.pathname = '/login';
+    redirectUrl.pathname = '/auth/login';
     return NextResponse.redirect(redirectUrl);
   }
 
@@ -88,7 +88,7 @@ export async function proxy(request: NextRequest) {
       }
       // Other unauthorized users go to login
       const redirectUrl = request.nextUrl.clone();
-      redirectUrl.pathname = '/login';
+      redirectUrl.pathname = '/auth/login';
       return NextResponse.redirect(redirectUrl);
     }
   }
@@ -97,7 +97,7 @@ export async function proxy(request: NextRequest) {
     // Student routes require student or teacher role
     if (profile.role !== 'student' && profile.role !== 'teacher' && profile.role !== 'admin') {
       const redirectUrl = request.nextUrl.clone();
-      redirectUrl.pathname = '/login';
+      redirectUrl.pathname = '/auth/login';
       return NextResponse.redirect(redirectUrl);
     }
   }

--- a/supabase/migrations/20251114214040_add_auto_create_profile_trigger.sql
+++ b/supabase/migrations/20251114214040_add_auto_create_profile_trigger.sql
@@ -1,0 +1,68 @@
+-- Create a trigger function that auto-creates a profile when a new auth user is created
+-- This ensures every authenticated user has a corresponding profile record
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+declare
+  default_org_id uuid;
+begin
+  -- Get the default demo organization ID
+  -- In production, this should be determined based on signup context
+  select id into default_org_id
+  from organizations
+  where slug = 'demo-school'
+  limit 1;
+
+  -- If no demo org exists, use a hardcoded UUID
+  -- This handles edge cases during initial setup
+  if default_org_id is null then
+    default_org_id := '00000000-0000-0000-0000-000000000001'::uuid;
+  end if;
+
+  -- Create the profile with default values
+  insert into public.profiles (id, organization_id, role, display_name, metadata)
+  values (
+    new.id,
+    default_org_id,
+    'student', -- Default role is student; can be updated later
+    coalesce(new.raw_user_meta_data->>'display_name', split_part(new.email, '@', 1)), -- Use display_name from metadata or email prefix
+    jsonb_build_object(
+      'email', new.email,
+      'created_via', 'auto_trigger'
+    )
+  );
+
+  return new;
+end;
+$$;
+
+-- Create the trigger on auth.users table
+-- This fires after a new user is inserted into the auth.users table
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- Backfill: Create profiles for any existing auth users that don't have profiles yet
+-- This handles users that were created before this trigger was added
+insert into public.profiles (id, organization_id, role, display_name, metadata)
+select
+  au.id,
+  coalesce(
+    (select id from organizations where slug = 'demo-school' limit 1),
+    '00000000-0000-0000-0000-000000000001'::uuid
+  ),
+  'student',
+  coalesce(au.raw_user_meta_data->>'display_name', split_part(au.email, '@', 1)),
+  jsonb_build_object(
+    'email', au.email,
+    'backfilled', true,
+    'backfilled_at', now()
+  )
+from auth.users au
+left join public.profiles p on p.id = au.id
+where p.id is null
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- Fixed incorrect `/login` redirect URLs (changed to `/auth/login`) in proxy.ts  
- Updated profile fetching to use `.maybeSingle()` instead of `.single()` to handle missing profiles gracefully
- Added database trigger to auto-create profiles for new auth users
- Backfilled profiles for existing auth users

## Problem
The live site login was failing with:
1. 404 errors for `/login?redirect=...` (should be `/auth/login`)
2. 406 (Not Acceptable) errors when fetching profiles that don't exist
3. Auth users existed but had no corresponding profile records

## Solution
1. **Redirect URLs**: Changed all `/login` references to `/auth/login` in `proxy.ts` (4 locations)
2. **Graceful profile handling**: Changed `.single()` to `.maybeSingle()` in both `proxy.ts` and `AuthProvider.tsx` to avoid 406 errors
3. **Auto-create profiles**: Added a database trigger that automatically creates a profile when a new auth user is created
4. **Backfill**: The migration includes a query to create profiles for any existing auth users that don't have profiles yet

## Testing
- ✅ Deployed migration to production database
- ✅ Pushed code changes to Vercel
- ⏳ Need to verify login flow works for demo_teacher and demo_student

## Fixes
Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)