### PR TITLE
fix: robust array handling for curriculum objectives

### DIFF
--- a/app/curriculum/page.test.tsx
+++ b/app/curriculum/page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import CurriculumPage from "./page";
+import CurriculumPage, { groupLessonsByUnit } from "./page";
 
 vi.mock("@/lib/db/drizzle", () => ({
   db: {
@@ -105,5 +105,56 @@ describe("CurriculumPage", () => {
     expect(
       screen.getByText(/Curriculum data isn't available yet/i)
     ).toBeInTheDocument();
+  });
+});
+
+describe("groupLessonsByUnit", () => {
+  it("ENSURES objectives is always an array (regression test)", () => {
+    const badDataScenarios: any[] = [
+      // String instead of array
+      {
+        id: "1",
+        unitNumber: 1,
+        title: "L1",
+        slug: "l1",
+        orderIndex: 1,
+        learningObjectives: "Bad string",
+        metadata: null,
+      },
+      // Object instead of array
+      {
+        id: "2",
+        unitNumber: 2,
+        title: "L2",
+        slug: "l2",
+        orderIndex: 1,
+        learningObjectives: { bad: "object" },
+        metadata: null,
+      },
+      // Null
+      {
+        id: "3",
+        unitNumber: 3,
+        title: "L3",
+        slug: "l3",
+        orderIndex: 1,
+        learningObjectives: null,
+        metadata: null,
+      },
+    ];
+
+    const result = groupLessonsByUnit(badDataScenarios);
+
+    // Check Unit 1 (String input)
+    const u1 = result.find((u) => u.unitNumber === 1);
+    expect(Array.isArray(u1?.objectives)).toBe(true);
+
+    // Check Unit 2 (Object input)
+    const u2 = result.find((u) => u.unitNumber === 2);
+    expect(Array.isArray(u2?.objectives)).toBe(true);
+
+    // Check Unit 3 (Null input)
+    const u3 = result.find((u) => u.unitNumber === 3);
+    expect(Array.isArray(u3?.objectives)).toBe(true);
   });
 });

--- a/app/curriculum/page.tsx
+++ b/app/curriculum/page.tsx
@@ -52,11 +52,17 @@ function deriveUnitDescription(row: LessonRow) {
 }
 
 function deriveObjectives(row: LessonRow) {
-  return (
-    row.metadata?.unitContent?.objectives?.content ??
-    row.learningObjectives ??
-    []
-  );
+  const fromMetadata = row.metadata?.unitContent?.objectives?.content;
+  if (Array.isArray(fromMetadata)) {
+    return fromMetadata;
+  }
+
+  const fromRow = row.learningObjectives;
+  if (Array.isArray(fromRow)) {
+    return fromRow;
+  }
+
+  return [];
 }
 
 export function groupLessonsByUnit(rows: LessonRow[]): UnitCurriculum[] {


### PR DESCRIPTION
Prevents runtime crash on /curriculum when learningObjectives is not an array. Added regression tests in app/curriculum/page.test.tsx.