### PR TITLE
fix: allow public access to /api routes

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -52,6 +52,7 @@ export async function proxy(request: NextRequest) {
     '/curriculum',
     '/login',
     '/auth',
+    '/api', // Allow API access
   ];
 
   // Check if current path is public


### PR DESCRIPTION
Updates proxy.ts to whitelist /api routes, enabling /api/test-db diagnostics without auth.