### PR TITLE
feat(schema): add lesson versioning and competency linking

### DIFF
--- a/drizzle/migrations/0003_nappy_skreet.sql
+++ b/drizzle/migrations/0003_nappy_skreet.sql
@@ -1,0 +1,52 @@
+CREATE TABLE "lesson_standards" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lesson_version_id" uuid NOT NULL,
+	"standard_id" uuid NOT NULL,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_lesson_standard" UNIQUE("lesson_version_id","standard_id")
+);
+--> statement-breakpoint
+CREATE TABLE "lesson_versions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lesson_id" uuid NOT NULL,
+	"version" integer NOT NULL,
+	"title" text,
+	"description" text,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_lesson_version" UNIQUE("lesson_id","version")
+);
+--> statement-breakpoint
+CREATE TABLE "phase_sections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"phase_version_id" uuid NOT NULL,
+	"sequence_order" integer NOT NULL,
+	"section_type" text NOT NULL,
+	"content" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_phase_section_sequence" UNIQUE("phase_version_id","sequence_order")
+);
+--> statement-breakpoint
+CREATE TABLE "phase_versions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lesson_version_id" uuid NOT NULL,
+	"phase_number" integer NOT NULL,
+	"title" text,
+	"estimated_minutes" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_lesson_version_phase" UNIQUE("lesson_version_id","phase_number")
+);
+--> statement-breakpoint
+ALTER TABLE "lessons" ADD COLUMN "current_version_id" uuid;--> statement-breakpoint
+ALTER TABLE "activities" ADD COLUMN "standard_id" uuid;--> statement-breakpoint
+ALTER TABLE "lesson_standards" ADD CONSTRAINT "lesson_standards_lesson_version_id_lesson_versions_id_fk" FOREIGN KEY ("lesson_version_id") REFERENCES "public"."lesson_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lesson_standards" ADD CONSTRAINT "lesson_standards_standard_id_competency_standards_id_fk" FOREIGN KEY ("standard_id") REFERENCES "public"."competency_standards"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lesson_versions" ADD CONSTRAINT "lesson_versions_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "phase_sections" ADD CONSTRAINT "phase_sections_phase_version_id_phase_versions_id_fk" FOREIGN KEY ("phase_version_id") REFERENCES "public"."phase_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "phase_versions" ADD CONSTRAINT "phase_versions_lesson_version_id_lesson_versions_id_fk" FOREIGN KEY ("lesson_version_id") REFERENCES "public"."lesson_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_lesson_standards_standard_id" ON "lesson_standards" USING btree ("standard_id");--> statement-breakpoint
+CREATE INDEX "idx_lesson_versions_lesson_id" ON "lesson_versions" USING btree ("lesson_id");--> statement-breakpoint
+CREATE INDEX "idx_lesson_versions_status" ON "lesson_versions" USING btree ("status");--> statement-breakpoint
+ALTER TABLE "activities" ADD CONSTRAINT "activities_standard_id_competency_standards_id_fk" FOREIGN KEY ("standard_id") REFERENCES "public"."competency_standards"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_activities_standard_id" ON "activities" USING btree ("standard_id");

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "37f912a0-97b1-4003-8c1e-e3d01b147db5",
-  "prevId": "42ee87bd-ae1e-4de9-a32f-99fa027e6156",
+  "id": "665a5ee4-6690-4e6a-a01e-ecd08c06cd4d",
+  "prevId": "37f912a0-97b1-4003-8c1e-e3d01b147db5",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -117,6 +117,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -141,6 +147,364 @@
           "nullsNotDistinct": false,
           "columns": [
             "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_standards": {
+      "name": "lesson_standards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_version_id": {
+          "name": "lesson_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard_id": {
+          "name": "standard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lesson_standards_standard_id": {
+          "name": "idx_lesson_standards_standard_id",
+          "columns": [
+            {
+              "expression": "standard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lesson_standards_lesson_version_id_lesson_versions_id_fk": {
+          "name": "lesson_standards_lesson_version_id_lesson_versions_id_fk",
+          "tableFrom": "lesson_standards",
+          "tableTo": "lesson_versions",
+          "columnsFrom": [
+            "lesson_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_standards_standard_id_competency_standards_id_fk": {
+          "name": "lesson_standards_standard_id_competency_standards_id_fk",
+          "tableFrom": "lesson_standards",
+          "tableTo": "competency_standards",
+          "columnsFrom": [
+            "standard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lesson_standard": {
+          "name": "uq_lesson_standard",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lesson_version_id",
+            "standard_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_versions": {
+      "name": "lesson_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lesson_versions_lesson_id": {
+          "name": "idx_lesson_versions_lesson_id",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lesson_versions_status": {
+          "name": "idx_lesson_versions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lesson_versions_lesson_id_lessons_id_fk": {
+          "name": "lesson_versions_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_versions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lesson_version": {
+          "name": "uq_lesson_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lesson_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phase_sections": {
+      "name": "phase_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phase_version_id": {
+          "name": "phase_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phase_sections_phase_version_id_phase_versions_id_fk": {
+          "name": "phase_sections_phase_version_id_phase_versions_id_fk",
+          "tableFrom": "phase_sections",
+          "tableTo": "phase_versions",
+          "columnsFrom": [
+            "phase_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_phase_section_sequence": {
+          "name": "uq_phase_section_sequence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phase_version_id",
+            "sequence_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phase_versions": {
+      "name": "phase_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_version_id": {
+          "name": "lesson_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_number": {
+          "name": "phase_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phase_versions_lesson_version_id_lesson_versions_id_fk": {
+          "name": "phase_versions_lesson_version_id_lesson_versions_id_fk",
+          "tableFrom": "phase_versions",
+          "tableTo": "lesson_versions",
+          "columnsFrom": [
+            "lesson_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lesson_version_phase": {
+          "name": "uq_lesson_version_phase",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lesson_version_id",
+            "phase_number"
           ]
         }
       },
@@ -273,6 +637,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "standard_id": {
+          "name": "standard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -288,8 +658,38 @@
           "default": "now()"
         }
       },
-      "indexes": {},
-      "foreignKeys": {},
+      "indexes": {
+        "idx_activities_standard_id": {
+          "name": "idx_activities_standard_id",
+          "columns": [
+            {
+              "expression": "standard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_standard_id_competency_standards_id_fk": {
+          "name": "activities_standard_id_competency_standards_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "competency_standards",
+          "columnsFrom": [
+            "standard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1764059842348,
       "tag": "0002_lying_boomer",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1764068179764,
+      "tag": "0003_nappy_skreet",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/activities.ts
+++ b/lib/db/schema/activities.ts
@@ -1,5 +1,6 @@
-import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { jsonb, pgTable, text, timestamp, uuid, index } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
+import { competencyStandards } from './competencies';
 
 const matchingItemSchema = z.object({
   id: z.string(),
@@ -1158,6 +1159,10 @@ export const activities = pgTable('activities', {
   description: text('description'),
   props: jsonb('props').$type<ActivityProps>().notNull(),
   gradingConfig: jsonb('grading_config').$type<GradingConfig | null>(),
+  standardId: uuid('standard_id')
+    .references(() => competencyStandards.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
-});
+}, (table) => ({
+  standardIdIdx: index('idx_activities_standard_id').on(table.standardId),
+}));

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -19,6 +19,7 @@
 
 export * from './organizations';
 export * from './lessons';
+export * from './lesson-versions';
 export * from './phases';
 export * from './activities';
 export * from './resources';

--- a/lib/db/schema/lesson-versions.ts
+++ b/lib/db/schema/lesson-versions.ts
@@ -1,0 +1,84 @@
+import { boolean, integer, jsonb, pgTable, text, timestamp, uuid, unique, index } from 'drizzle-orm/pg-core';
+import { lessons } from './lessons';
+import { competencyStandards } from './competencies';
+
+/**
+ * Lesson Versions
+ *
+ * Implements versioned content model for safe authoring.
+ * Each lesson can have multiple versions (draft, review, published, archived).
+ */
+export const lessonVersions = pgTable('lesson_versions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  lessonId: uuid('lesson_id')
+    .notNull()
+    .references(() => lessons.id, { onDelete: 'cascade' }),
+  version: integer('version').notNull(),
+  title: text('title'),
+  description: text('description'),
+  status: text('status').$type<'draft' | 'review' | 'published' | 'archived'>().notNull().default('draft'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  lessonVersionUnique: unique('uq_lesson_version').on(table.lessonId, table.version),
+  lessonIdIdx: index('idx_lesson_versions_lesson_id').on(table.lessonId),
+  statusIdx: index('idx_lesson_versions_status').on(table.status),
+}));
+
+/**
+ * Phase Versions
+ *
+ * Links phases to specific lesson versions.
+ * Each lesson version has up to 6 phases.
+ */
+export const phaseVersions = pgTable('phase_versions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  lessonVersionId: uuid('lesson_version_id')
+    .notNull()
+    .references(() => lessonVersions.id, { onDelete: 'cascade' }),
+  phaseNumber: integer('phase_number').notNull(),
+  title: text('title'),
+  estimatedMinutes: integer('estimated_minutes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  lessonPhaseUnique: unique('uq_lesson_version_phase').on(table.lessonVersionId, table.phaseNumber),
+}));
+
+/**
+ * Phase Sections
+ *
+ * Structured content storage replacing monolithic JSONB blobs.
+ * Each section represents a content block within a phase.
+ */
+export const phaseSections = pgTable('phase_sections', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  phaseVersionId: uuid('phase_version_id')
+    .notNull()
+    .references(() => phaseVersions.id, { onDelete: 'cascade' }),
+  sequenceOrder: integer('sequence_order').notNull(),
+  sectionType: text('section_type').$type<'text' | 'callout' | 'activity' | 'video' | 'image'>().notNull(),
+  content: jsonb('content').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  phaseSequenceUnique: unique('uq_phase_section_sequence').on(table.phaseVersionId, table.sequenceOrder),
+}));
+
+/**
+ * Lesson Standards
+ *
+ * Junction table linking lesson versions to competency standards.
+ * Replaces JSONB array for referential integrity.
+ */
+export const lessonStandards = pgTable('lesson_standards', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  lessonVersionId: uuid('lesson_version_id')
+    .notNull()
+    .references(() => lessonVersions.id, { onDelete: 'cascade' }),
+  standardId: uuid('standard_id')
+    .notNull()
+    .references(() => competencyStandards.id, { onDelete: 'restrict' }),
+  isPrimary: boolean('is_primary').notNull().default(false),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  lessonStandardUnique: unique('uq_lesson_standard').on(table.lessonVersionId, table.standardId),
+  standardIdIdx: index('idx_lesson_standards_standard_id').on(table.standardId),
+}));

--- a/lib/db/schema/lessons.ts
+++ b/lib/db/schema/lessons.ts
@@ -163,6 +163,7 @@ export const lessons = pgTable('lessons', {
   learningObjectives: jsonb('learning_objectives').$type<string[] | null>(),
   orderIndex: integer('order_index').notNull(),
   metadata: jsonb('metadata').$type<LessonMetadata | null>(),
+  currentVersionId: uuid('current_version_id'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });

--- a/lib/db/schema/relations.ts
+++ b/lib/db/schema/relations.ts
@@ -1,13 +1,19 @@
 import { relations } from 'drizzle-orm';
 import { lessons } from './lessons';
+import { lessonVersions, phaseVersions, phaseSections, lessonStandards } from './lesson-versions';
 import { phases } from './phases';
 import { studentProgress } from './student-progress';
 import { profiles } from './profiles';
 import { competencyStandards, studentCompetency } from './competencies';
 import { activities } from './activities';
 
-export const lessonsRelations = relations(lessons, ({ many }) => ({
+export const lessonsRelations = relations(lessons, ({ one, many }) => ({
   phases: many(phases),
+  versions: many(lessonVersions),
+  currentVersion: one(lessonVersions, {
+    fields: [lessons.currentVersionId],
+    references: [lessonVersions.id],
+  }),
 }));
 
 export const phasesRelations = relations(phases, ({ one, many }) => ({
@@ -41,6 +47,8 @@ export const profilesRelations = relations(profiles, ({ many }) => ({
 
 export const competencyStandardsRelations = relations(competencyStandards, ({ many }) => ({
   studentCompetencies: many(studentCompetency),
+  lessonStandards: many(lessonStandards),
+  activities: many(activities),
 }));
 
 export const studentCompetencyRelations = relations(studentCompetency, ({ one }) => ({
@@ -64,6 +72,46 @@ export const studentCompetencyRelations = relations(studentCompetency, ({ one })
   }),
 }));
 
-export const activitiesRelations = relations(activities, ({ many }) => ({
+export const activitiesRelations = relations(activities, ({ one, many }) => ({
   studentCompetencies: many(studentCompetency),
+  standard: one(competencyStandards, {
+    fields: [activities.standardId],
+    references: [competencyStandards.id],
+  }),
+}));
+
+// Lesson Versioning Relations
+export const lessonVersionsRelations = relations(lessonVersions, ({ one, many }) => ({
+  lesson: one(lessons, {
+    fields: [lessonVersions.lessonId],
+    references: [lessons.id],
+  }),
+  phaseVersions: many(phaseVersions),
+  standards: many(lessonStandards),
+}));
+
+export const phaseVersionsRelations = relations(phaseVersions, ({ one, many }) => ({
+  lessonVersion: one(lessonVersions, {
+    fields: [phaseVersions.lessonVersionId],
+    references: [lessonVersions.id],
+  }),
+  sections: many(phaseSections),
+}));
+
+export const phaseSectionsRelations = relations(phaseSections, ({ one }) => ({
+  phaseVersion: one(phaseVersions, {
+    fields: [phaseSections.phaseVersionId],
+    references: [phaseVersions.id],
+  }),
+}));
+
+export const lessonStandardsRelations = relations(lessonStandards, ({ one }) => ({
+  lessonVersion: one(lessonVersions, {
+    fields: [lessonStandards.lessonVersionId],
+    references: [lessonVersions.id],
+  }),
+  standard: one(competencyStandards, {
+    fields: [lessonStandards.standardId],
+    references: [competencyStandards.id],
+  }),
 }));


### PR DESCRIPTION
## Summary
- Creates versioned content model: `lesson_versions`, `phase_versions`, `phase_sections`
- Creates `lesson_standards` junction table for referential integrity
- Adds `activities.standard_id` FK to competency_standards
- Adds `lessons.current_version_id` for version management
- Establishes all Drizzle relations

## Changes
- New: `lib/db/schema/lesson-versions.ts`
- Updated: `lib/db/schema/activities.ts`
- Updated: `lib/db/schema/lessons.ts`
- Updated: `lib/db/schema/index.ts`
- Updated: `lib/db/schema/relations.ts`
- Generated: `drizzle/migrations/0003_nappy_skreet.sql`

## Test plan
- [x] Migration generates without errors
- [x] No new lint errors introduced
- [ ] Migration applies successfully (to be verified on merge)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)