### PR TITLE
feat: Create LessonStepper Component with Progress API (#156)

### DIFF
--- a/app/api/lessons/[lessonId]/progress/route.test.ts
+++ b/app/api/lessons/[lessonId]/progress/route.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockOrder = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+      from: mockFrom,
+    }),
+  ),
+}));
+
+const { GET } = await import('./route');
+
+function buildContext(lessonId: string) {
+  return {
+    params: Promise.resolve({ lessonId }),
+  };
+}
+
+describe('GET /api/lessons/[lessonId]/progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    });
+
+    // Setup default chain
+    const defaultData = {
+      data: [
+        {
+          id: 'phase-1',
+          phase_number: 1,
+          title: 'Introduction',
+          student_progress: [{ status: 'completed', started_at: '2024-01-01', completed_at: '2024-01-01', time_spent_seconds: 300 }],
+        },
+        {
+          id: 'phase-2',
+          phase_number: 2,
+          title: 'Theory',
+          student_progress: [{ status: 'in_progress', started_at: '2024-01-02', completed_at: null, time_spent_seconds: 150 }],
+        },
+        {
+          id: 'phase-3',
+          phase_number: 3,
+          title: 'Practice',
+          student_progress: [],
+        },
+        {
+          id: 'phase-4',
+          phase_number: 4,
+          title: 'Application',
+          student_progress: [],
+        },
+        {
+          id: 'phase-5',
+          phase_number: 5,
+          title: 'Assessment',
+          student_progress: [],
+        },
+        {
+          id: 'phase-6',
+          phase_number: 6,
+          title: 'Reflection',
+          student_progress: [],
+        },
+      ],
+      error: null,
+    };
+
+    mockOrder.mockReturnValue(defaultData);
+
+    // Second .eq() returns an object with .order()
+    const secondEq = vi.fn().mockReturnValue({ order: mockOrder });
+
+    // First .eq() returns an object with .eq()
+    mockEq.mockReturnValue({ eq: secondEq });
+
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+  });
+
+  it('returns 401 when no authenticated user is found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it('validates the lessonId parameter and rejects invalid UUIDs', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/lessons/not-a-uuid/progress'),
+      buildContext('not-a-uuid'),
+    );
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.error).toBe('Invalid parameters');
+  });
+
+  it('returns 404 when lesson has no phases', async () => {
+    const emptyData = { data: [], error: null };
+    mockOrder.mockReturnValue(emptyData);
+
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toMatch(/lesson not found/i);
+  });
+
+  it('fetches phase progress for the authenticated user', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFrom).toHaveBeenCalledWith('phases');
+    expect(mockSelect).toHaveBeenCalledWith(expect.stringContaining('student_progress'));
+    // First .eq() is called with lesson_id
+    expect(mockEq).toHaveBeenCalledWith('lesson_id', 'b4b82cad-64f6-46cc-933a-5bb8299a23d4');
+    // The chain ensures the second .eq() is called via the secondEq mock
+  });
+
+  it('calculates correct phase statuses based on progress', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.phases).toHaveLength(6);
+
+    // Phase 1: completed
+    expect(json.phases[0]).toMatchObject({
+      phaseNumber: 1,
+      phaseId: 'phase-1',
+      status: 'completed',
+      startedAt: '2024-01-01',
+      completedAt: '2024-01-01',
+      timeSpentSeconds: 300,
+    });
+
+    // Phase 2: current (in_progress)
+    expect(json.phases[1]).toMatchObject({
+      phaseNumber: 2,
+      phaseId: 'phase-2',
+      status: 'current',
+      startedAt: '2024-01-02',
+      completedAt: null,
+      timeSpentSeconds: 150,
+    });
+
+    // Phase 3: locked (previous phase not completed)
+    expect(json.phases[2]).toMatchObject({
+      phaseNumber: 3,
+      phaseId: 'phase-3',
+      status: 'locked',
+      startedAt: null,
+      completedAt: null,
+      timeSpentSeconds: null,
+    });
+
+    // Phases 4-6: locked
+    expect(json.phases[3].status).toBe('locked');
+    expect(json.phases[4].status).toBe('locked');
+    expect(json.phases[5].status).toBe('locked');
+  });
+
+  it('marks first phase as available when no progress exists', async () => {
+    const noProgressData = {
+      data: [
+        { id: 'phase-1', phase_number: 1, title: 'Intro', student_progress: [] },
+        { id: 'phase-2', phase_number: 2, title: 'Theory', student_progress: [] },
+      ],
+      error: null,
+    };
+    mockOrder.mockReturnValue(noProgressData);
+
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.phases[0].status).toBe('available');
+    expect(json.phases[1].status).toBe('locked');
+  });
+
+  it('marks next phase as available when previous phase is completed', async () => {
+    const progressData = {
+      data: [
+        { id: 'phase-1', phase_number: 1, title: 'Intro', student_progress: [{ status: 'completed' }] },
+        { id: 'phase-2', phase_number: 2, title: 'Theory', student_progress: [] },
+        { id: 'phase-3', phase_number: 3, title: 'Practice', student_progress: [] },
+      ],
+      error: null,
+    };
+    mockOrder.mockReturnValue(progressData);
+
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.phases[0].status).toBe('completed');
+    expect(json.phases[1].status).toBe('available');
+    expect(json.phases[2].status).toBe('locked');
+  });
+
+  it('propagates Supabase errors', async () => {
+    const errorData = { data: null, error: { message: 'Database error' } };
+    mockOrder.mockReturnValue(errorData);
+
+    const response = await GET(
+      new Request('http://localhost/api/lessons/lesson-123/progress'),
+      buildContext('b4b82cad-64f6-46cc-933a-5bb8299a23d4'),
+    );
+
+    expect(response.status).toBe(500);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/database error/i);
+  });
+});

--- a/app/api/lessons/[lessonId]/progress/route.ts
+++ b/app/api/lessons/[lessonId]/progress/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createClient } from '@/lib/supabase/server';
+
+const paramsSchema = z.object({
+  lessonId: z.string().uuid('Invalid lesson ID format'),
+});
+
+type PhaseStatus = 'completed' | 'current' | 'available' | 'locked';
+
+interface PhaseProgressResponse {
+  phaseNumber: number;
+  phaseId: string;
+  status: PhaseStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  timeSpentSeconds: number | null;
+}
+
+interface ProgressResponse {
+  phases: PhaseProgressResponse[];
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ lessonId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const {
+      data,
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError) {
+      return NextResponse.json(
+        { error: authError.message ?? 'Unauthorized' },
+        { status: 401 },
+      );
+    }
+
+    const user = data?.user;
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Validate lessonId parameter
+    const resolvedParams = await params;
+    const parsed = paramsSchema.safeParse(resolvedParams);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid parameters',
+          details: parsed.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { lessonId } = parsed.data;
+
+    // Fetch all phases for this lesson with their progress
+    const { data: phasesData, error: phasesError } = await supabase
+      .from('phases')
+      .select(`
+        id,
+        phase_number,
+        title,
+        student_progress (
+          status,
+          started_at,
+          completed_at,
+          time_spent_seconds
+        )
+      `)
+      .eq('lesson_id', lessonId)
+      .eq('student_progress.user_id', user.id)
+      .order('phase_number', { ascending: true });
+
+    if (phasesError) {
+      console.error('Phases query error:', phasesError);
+      return NextResponse.json(
+        { error: phasesError.message ?? 'Unable to fetch phases' },
+        { status: 500 },
+      );
+    }
+
+    if (!phasesData || phasesData.length === 0) {
+      return NextResponse.json(
+        { error: 'Lesson not found or has no phases' },
+        { status: 404 },
+      );
+    }
+
+    // Calculate status for each phase
+    const phases: PhaseProgressResponse[] = phasesData.map((phase, index) => {
+      const progress = Array.isArray(phase.student_progress) && phase.student_progress.length > 0
+        ? phase.student_progress[0]
+        : null;
+
+      let status: PhaseStatus;
+
+      if (progress?.status === 'completed') {
+        status = 'completed';
+      } else if (progress?.status === 'in_progress') {
+        status = 'current';
+      } else {
+        // Phase is available if it's the first phase OR if the previous phase is completed
+        if (index === 0) {
+          status = 'available';
+        } else {
+          const previousPhase = phasesData[index - 1];
+          const previousProgress = Array.isArray(previousPhase.student_progress) && previousPhase.student_progress.length > 0
+            ? previousPhase.student_progress[0]
+            : null;
+
+          status = previousProgress?.status === 'completed' ? 'available' : 'locked';
+        }
+      }
+
+      return {
+        phaseNumber: phase.phase_number,
+        phaseId: phase.id,
+        status,
+        startedAt: progress?.started_at ?? null,
+        completedAt: progress?.completed_at ?? null,
+        timeSpentSeconds: progress?.time_spent_seconds ?? null,
+      };
+    });
+
+    const response: ProgressResponse = { phases };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('Unexpected error:', error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : 'Unexpected error while fetching progress',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/lesson/LessonStepper.test.tsx
+++ b/components/lesson/LessonStepper.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { LessonStepper, type StepperPhase } from './LessonStepper';
+
+const mockPhases: StepperPhase[] = [
+  { phaseNumber: 1, phaseId: 'phase-1', title: 'Introduction', status: 'completed' },
+  { phaseNumber: 2, phaseId: 'phase-2', title: 'Theory', status: 'current' },
+  { phaseNumber: 3, phaseId: 'phase-3', title: 'Practice', status: 'available' },
+  { phaseNumber: 4, phaseId: 'phase-4', title: 'Application', status: 'locked' },
+  { phaseNumber: 5, phaseId: 'phase-5', title: 'Assessment', status: 'locked' },
+  { phaseNumber: 6, phaseId: 'phase-6', title: 'Reflection', status: 'locked' },
+];
+
+describe('LessonStepper', () => {
+  it('renders all phase steps with correct labels', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    // Component renders both desktop and mobile views, so we get multiple elements
+    expect(screen.getAllByLabelText('Phase 1: Introduction').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByLabelText('Phase 2: Theory').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByLabelText('Phase 3: Practice').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByLabelText('Phase 4: Application').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByLabelText('Phase 5: Assessment').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByLabelText('Phase 6: Reflection').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('marks the current phase with aria-current="step"', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    const currentPhaseButtons = screen.getAllByLabelText('Phase 2: Theory');
+    currentPhaseButtons.forEach(button => {
+      expect(button).toHaveAttribute('aria-current', 'step');
+    });
+
+    const otherPhaseButtons = screen.getAllByLabelText('Phase 1: Introduction');
+    otherPhaseButtons.forEach(button => {
+      expect(button).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  it('allows clicking on completed phases', async () => {
+    const handlePhaseClick = vi.fn();
+    render(
+      <LessonStepper
+        phases={mockPhases}
+        currentPhase={2}
+        onPhaseClick={handlePhaseClick}
+      />
+    );
+
+    const completedPhaseButtons = screen.getAllByLabelText('Phase 1: Introduction');
+    await userEvent.click(completedPhaseButtons[0]);
+
+    expect(handlePhaseClick).toHaveBeenCalledWith(1, 'phase-1');
+  });
+
+  it('allows clicking on current phase', async () => {
+    const handlePhaseClick = vi.fn();
+    render(
+      <LessonStepper
+        phases={mockPhases}
+        currentPhase={2}
+        onPhaseClick={handlePhaseClick}
+      />
+    );
+
+    const currentPhaseButtons = screen.getAllByLabelText('Phase 2: Theory');
+    await userEvent.click(currentPhaseButtons[0]);
+
+    expect(handlePhaseClick).toHaveBeenCalledWith(2, 'phase-2');
+  });
+
+  it('disables locked phases and does not trigger onClick', async () => {
+    const handlePhaseClick = vi.fn();
+    render(
+      <LessonStepper
+        phases={mockPhases}
+        currentPhase={2}
+        onPhaseClick={handlePhaseClick}
+      />
+    );
+
+    const lockedPhaseButtons = screen.getAllByLabelText('Phase 4: Application');
+    lockedPhaseButtons.forEach(button => {
+      expect(button).toBeDisabled();
+    });
+
+    await userEvent.click(lockedPhaseButtons[0]);
+    expect(handlePhaseClick).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger onClick for available but not started phases', async () => {
+    const handlePhaseClick = vi.fn();
+    render(
+      <LessonStepper
+        phases={mockPhases}
+        currentPhase={2}
+        onPhaseClick={handlePhaseClick}
+      />
+    );
+
+    const availablePhaseButtons = screen.getAllByLabelText('Phase 3: Practice');
+    availablePhaseButtons.forEach(button => {
+      expect(button).toBeDisabled();
+    });
+
+    await userEvent.click(availablePhaseButtons[0]);
+    expect(handlePhaseClick).not.toHaveBeenCalled();
+  });
+
+  it('shows lock icon title for locked phases', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    const lockedPhaseButtons = screen.getAllByLabelText('Phase 4: Application');
+    lockedPhaseButtons.forEach(button => {
+      expect(button).toHaveAttribute('title', 'Complete previous phase to unlock');
+    });
+  });
+
+  it('shows phase title for unlocked phases', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    const completedPhaseButtons = screen.getAllByLabelText('Phase 1: Introduction');
+    completedPhaseButtons.forEach(button => {
+      expect(button).toHaveAttribute('title', 'Introduction');
+    });
+
+    const currentPhaseButtons = screen.getAllByLabelText('Phase 2: Theory');
+    currentPhaseButtons.forEach(button => {
+      expect(button).toHaveAttribute('title', 'Theory');
+    });
+  });
+
+  it('renders navigation landmark with proper aria-label', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    const nav = screen.getByRole('navigation', { name: /lesson progress stepper/i });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('renders all 6 phases when provided', () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={1} />);
+
+    const allButtons = screen.getAllByRole('button');
+    // Desktop view shows 6 buttons + mobile view shows 6 buttons = 12 total
+    // But we'll just check that we have at least 6
+    expect(allButtons.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('handles phases with all completed status', async () => {
+    const allCompletedPhases: StepperPhase[] = mockPhases.map((phase) => ({
+      ...phase,
+      status: 'completed' as const,
+    }));
+
+    const handlePhaseClick = vi.fn();
+    render(
+      <LessonStepper
+        phases={allCompletedPhases}
+        currentPhase={6}
+        onPhaseClick={handlePhaseClick}
+      />
+    );
+
+    // All phases should be clickable
+    for (let i = 1; i <= 6; i++) {
+      const buttons = screen.getAllByLabelText(new RegExp(`Phase ${i}:`));
+      buttons.forEach(button => {
+        expect(button).not.toBeDisabled();
+      });
+    }
+  });
+
+  it('handles empty onPhaseClick gracefully', async () => {
+    render(<LessonStepper phases={mockPhases} currentPhase={2} />);
+
+    const completedPhaseButtons = screen.getAllByLabelText('Phase 1: Introduction');
+    // Should not throw
+    await expect(userEvent.click(completedPhaseButtons[0])).resolves.not.toThrow();
+  });
+});

--- a/components/lesson/LessonStepper.tsx
+++ b/components/lesson/LessonStepper.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { Circle, CircleDot, Check, Lock } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import type { PhaseStatus } from '@/hooks/usePhaseProgress';
+
+export interface StepperPhase {
+  phaseNumber: number;
+  phaseId: string;
+  title: string;
+  status: PhaseStatus;
+}
+
+interface LessonStepperProps {
+  phases: StepperPhase[];
+  currentPhase: number;
+  onPhaseClick?: (phaseNumber: number, phaseId: string) => void;
+  className?: string;
+}
+
+export function LessonStepper({
+  phases,
+  currentPhase,
+  onPhaseClick,
+  className,
+}: LessonStepperProps) {
+  const handlePhaseClick = (phase: StepperPhase) => {
+    // Only allow clicking on completed or current phases
+    if (phase.status === 'completed' || phase.status === 'current') {
+      onPhaseClick?.(phase.phaseNumber, phase.phaseId);
+    }
+  };
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Lesson progress stepper"
+      className={cn('w-full', className)}
+    >
+      {/* Desktop: Horizontal stepper */}
+      <ol className="hidden md:flex items-center justify-between gap-2">
+        {phases.map((phase, index) => (
+          <li key={phase.phaseId} className="flex flex-1 items-center">
+            <StepButton
+              phase={phase}
+              isCurrent={phase.phaseNumber === currentPhase}
+              onClick={() => handlePhaseClick(phase)}
+            />
+            {index < phases.length - 1 && (
+              <StepConnector completed={phase.status === 'completed'} />
+            )}
+          </li>
+        ))}
+      </ol>
+
+      {/* Mobile: Compact horizontal scroll */}
+      <ol className="flex md:hidden items-center gap-3 overflow-x-auto pb-2">
+        {phases.map((phase) => (
+          <li key={phase.phaseId} className="flex-shrink-0">
+            <StepButton
+              phase={phase}
+              isCurrent={phase.phaseNumber === currentPhase}
+              onClick={() => handlePhaseClick(phase)}
+              compact
+            />
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+interface StepButtonProps {
+  phase: StepperPhase;
+  isCurrent: boolean;
+  onClick: () => void;
+  compact?: boolean;
+}
+
+function StepButton({ phase, isCurrent, onClick, compact = false }: StepButtonProps) {
+  const isClickable = phase.status === 'completed' || phase.status === 'current';
+  const isLocked = phase.status === 'locked';
+
+  const statusColors = {
+    completed: 'bg-green-600 text-white border-green-600',
+    current: 'bg-blue-600 text-white border-blue-600',
+    available: 'bg-white text-gray-700 border-gray-300 hover:border-blue-400',
+    locked: 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed',
+  };
+
+  const tooltipText = isLocked
+    ? 'Complete previous phase to unlock'
+    : phase.title;
+
+  const StepIcon = () => {
+    switch (phase.status) {
+      case 'completed':
+        return <Check className="h-4 w-4" aria-hidden="true" />;
+      case 'current':
+        return <CircleDot className="h-4 w-4" aria-hidden="true" />;
+      case 'locked':
+        return <Lock className="h-4 w-4" aria-hidden="true" />;
+      default:
+        return <Circle className="h-4 w-4" aria-hidden="true" />;
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!isClickable}
+      aria-label={`Phase ${phase.phaseNumber}: ${phase.title}`}
+      aria-current={isCurrent ? 'step' : undefined}
+      title={tooltipText}
+      className={cn(
+        'flex items-center justify-center rounded-full border-2 transition-all',
+        'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+        compact ? 'h-10 w-10' : 'h-12 w-12',
+        statusColors[phase.status],
+        isClickable && !isLocked && 'hover:scale-110',
+      )}
+    >
+      {compact ? (
+        <span className="text-sm font-semibold">{phase.phaseNumber}</span>
+      ) : (
+        <span className="sr-only">Phase {phase.phaseNumber}</span>
+      )}
+      {!compact && <StepIcon />}
+    </button>
+  );
+}
+
+interface StepConnectorProps {
+  completed: boolean;
+}
+
+function StepConnector({ completed }: StepConnectorProps) {
+  return (
+    <div
+      className={cn(
+        'h-0.5 flex-1 transition-colors',
+        completed ? 'bg-green-600' : 'bg-gray-300',
+      )}
+      aria-hidden="true"
+    />
+  );
+}

--- a/hooks/usePhaseProgress.ts
+++ b/hooks/usePhaseProgress.ts
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+export type PhaseStatus = 'completed' | 'current' | 'available' | 'locked';
+
+export interface PhaseProgress {
+  phaseNumber: number;
+  phaseId: string;
+  status: PhaseStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  timeSpentSeconds: number | null;
+}
+
+export interface ProgressData {
+  phases: PhaseProgress[];
+}
+
+interface UsePhaseProgressResult {
+  data: ProgressData | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+const STALE_TIME = 60 * 1000; // 60 seconds
+
+// Simple in-memory cache
+const cache = new Map<string, { data: ProgressData; timestamp: number }>();
+
+export function usePhaseProgress(lessonId: string | undefined): UsePhaseProgressResult {
+  const [data, setData] = useState<ProgressData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProgress = useCallback(async () => {
+    if (!lessonId) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setIsError(false);
+      setError(null);
+
+      // Check cache first
+      const cached = cache.get(lessonId);
+      if (cached && Date.now() - cached.timestamp < STALE_TIME) {
+        setData(cached.data);
+        setIsLoading(false);
+        return;
+      }
+
+      const response = await fetch(`/api/lessons/${lessonId}/progress`);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const progressData: ProgressData = await response.json();
+
+      // Update cache
+      cache.set(lessonId, { data: progressData, timestamp: Date.now() });
+
+      setData(progressData);
+    } catch (err) {
+      const errorObj = err instanceof Error ? err : new Error('Failed to fetch progress');
+      setError(errorObj);
+      setIsError(true);
+      console.error('Error fetching phase progress:', errorObj);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [lessonId]);
+
+  useEffect(() => {
+    fetchProgress();
+
+    // Refetch on window focus
+    const handleFocus = () => {
+      fetchProgress();
+    };
+
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [fetchProgress]);
+
+  return {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch: fetchProgress,
+  };
+}


### PR DESCRIPTION
## Summary
Implements visual lesson stepper component with underlying progress tracking and API endpoint.

Closes #156

## Implementation Details

### 1. Progress API Endpoint ✅
**File**: `app/api/lessons/[lessonId]/progress/route.ts`

Features:
- GET endpoint for fetching all phase progress in a lesson
- Authentication via Supabase
- UUID validation with Zod  
- Status calculation logic:
  - `completed`: phase is done
  - `current`: phase in progress
  - `available`: first phase OR previous completed
  - `locked`: previous phase incomplete
- Returns timing metadata (startedAt, completedAt, timeSpentSeconds)

### 2. React Hook ✅
**File**: `hooks/usePhaseProgress.ts`

Features:
- Custom `usePhaseProgress` hook with native fetch
- In-memory caching with 60-second stale time
- Auto-refetch on window focus
- Loading, error, and success states
- Manual refetch function
- Full TypeScript type safety

### 3. LessonStepper Component ✅
**File**: `components/lesson/LessonStepper.tsx`

Visual Design:
- Horizontal stepper showing all 6 phases
- Phase status icons:
  - ✅ Completed: Green checkmark
  - 🔵 Current: Blue filled circle
  - ⭕ Available: Gray empty circle
  - 🔒 Locked: Gray lock icon
- Connecting lines between phases
- Responsive: desktop horizontal / mobile compact scroll

Interaction:
- Clickable: completed and current phases
- Disabled: available (not started) and locked phases
- Tooltips: "Complete previous phase to unlock" for locked
- Phase titles shown for unlocked phases

Accessibility:
- `<nav>` landmark with `aria-label="Lesson progress"`
- Descriptive `aria-label` for each phase button
- `aria-current="step"` for current phase
- Keyboard navigation support
- Focus styles for accessibility

### 4. Comprehensive Tests ✅

**API Tests** (`route.test.ts`) - 8 tests:
- ✅ 401 on unauthenticated requests
- ✅ UUID validation for lessonId
- ✅ 404 when lesson has no phases
- ✅ Fetches progress for authenticated user
- ✅ Calculates correct phase statuses
- ✅ First phase available when no progress
- ✅ Next phase available after previous completed
- ✅ Supabase error propagation

**Component Tests** (`LessonStepper.test.tsx`) - 12 tests:
- ✅ Renders all phase steps with labels
- ✅ Marks current phase with aria-current
- ✅ Allows clicking completed phases
- ✅ Allows clicking current phase
- ✅ Disables locked phases
- ✅ Disables available (not started) phases
- ✅ Shows lock icon title for locked phases
- ✅ Shows phase title for unlocked phases
- ✅ Renders navigation landmark
- ✅ Handles all 6 phases
- ✅ Handles all completed status
- ✅ Gracefully handles missing onPhaseClick

**Total**: 20/20 tests passing

## Architecture Decisions

**No New Schema**: Reused existing `student_progress` table with `phaseId` relationships from issue #155

**No External Dependencies**: Custom fetch hook instead of React Query to avoid new dependencies

**Server-Side Status**: Backend calculates phase status for security and consistency

**Caching Strategy**: 60-second stale time balances performance vs freshness

**Responsive Design**: Separate layouts for desktop (horizontal) and mobile (compact scroll)

**Accessibility First**: Full ARIA support, semantic HTML, keyboard navigation

## Files Changed

**Created (5 files)**:
1. `app/api/lessons/[lessonId]/progress/route.ts` - API endpoint
2. `app/api/lessons/[lessonId]/progress/route.test.ts` - API tests
3. `hooks/usePhaseProgress.ts` - React hook
4. `components/lesson/LessonStepper.tsx` - Component
5. `components/lesson/LessonStepper.test.tsx` - Component tests

## Acceptance Criteria

- [x] `student_phase_progress` schema verified (exists from #155)
- [x] API returns correct states based on DB data
- [x] Stepper renders correct state for all phases
- [x] Navigation blocked for locked steps (UI level)
- [x] Accessibility tags verified (ARIA labels, navigation landmark)

## Test Results

- Build: ✅ Successful
- Tests: ✅ 20/20 passing
- New route: ✅ `/api/lessons/[lessonId]/progress` generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>